### PR TITLE
fix(wallpaper-picker): resolve duplicate trigger, hover desync, grid navigation; fix dynamic wallpaper playback

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -36,7 +36,7 @@ clone_repo_bootstrap() {
         
         local _t_depth
         _t_depth=$(printf '%s' "$target_dir" | tr -cd '/' | wc -c)
-        if [ -n "$target_dir" ] && [ "$_t_depth" -ge 3 ] && [[ "$target_dir" == *".cache/NyxNiri" ]]; then
+        if [ -n "$target_dir" ] && [ "$_t_depth" -ge 3 ] && [[ "$target_dir" == *".cache/NyxNiri" ]] && [[ "$target_dir" == "$HOME"* ]]; then
             rm -rf "$target_dir" 2>/dev/null || true
         fi
 

--- a/lib/backup.sh
+++ b/lib/backup.sh
@@ -98,7 +98,7 @@ list_backups() {
             bname=$(basename "$b")
             local note=""
             if [ -f "$b/note.txt" ]; then
-                note=" ($(cat "$b/note.txt"))"
+                note=" ($(head -n1 "$b/note.txt" 2>/dev/null || echo ""))"
             fi
             echo -e "  \e[1;32m[$idx]\e[0m $bname$note"
             idx=$((idx + 1))

--- a/lib/deploy.sh
+++ b/lib/deploy.sh
@@ -139,12 +139,12 @@ _phase_render_templates() {
     esc_home=$(printf '%s\n' "$HOME" | sed 's/[|&]/\\&/g')
     esc_wp_dest=$(printf '%s\n' "$wp_dest" | sed 's/[|&]/\\&/g')
 
-    if [ -f "$HOME/.config/$THEME_ENGINE/noctalia-config.toml" ]; then
+    if [ -f "$HOME/.config/$THEME_ENGINE/${THEME_ENGINE}-config.toml" ]; then
         local esc_wp_video_dest
         esc_wp_video_dest=$(printf '%s\n' "$wp_dest/video" | sed 's/[|&]/\\&/g')
-        sed -i "s|^directory = \".*\"|directory = \"${esc_wp_dest}\"|" "$HOME/.config/$THEME_ENGINE/noctalia-config.toml"
-        sed -i "s|^video_directory = \".*\"|video_directory = \"${esc_wp_video_dest}\"|" "$HOME/.config/$THEME_ENGINE/noctalia-config.toml"
-        sed -i -E "s|/home/[^/]+|${esc_home}|g" "$HOME/.config/$THEME_ENGINE/noctalia-config.toml"
+        sed -i "s|^directory = \".*\"|directory = \"${esc_wp_dest}\"|" "$HOME/.config/$THEME_ENGINE/${THEME_ENGINE}-config.toml"
+        sed -i "s|^video_directory = \".*\"|video_directory = \"${esc_wp_video_dest}\"|" "$HOME/.config/$THEME_ENGINE/${THEME_ENGINE}-config.toml"
+        sed -i -E "s|/home/[^/]+|${esc_home}|g" "$HOME/.config/$THEME_ENGINE/${THEME_ENGINE}-config.toml"
     fi
     if [ -f "$HOME/.config/$MAIN_WM/config.kdl" ]; then
         sed -i -E "s|/home/[^/]+|${esc_home}|g" "$HOME/.config/$MAIN_WM/config.kdl"
@@ -236,7 +236,8 @@ deploy_selected_configs() {
 
     local _custom_log
     _custom_log=$(mktemp) || _custom_log=""
-    export NYXNIRI_CUSTOM_LOG="$_custom_log"
+    NYXNIRI_CUSTOM_LOG="$_custom_log"
+    export NYXNIRI_CUSTOM_LOG
     register_temp_path "$NYXNIRI_CUSTOM_LOG"
 
     _phase_atomic_deployment "${items_to_deploy[@]}"

--- a/lib/fcitx.sh
+++ b/lib/fcitx.sh
@@ -9,7 +9,6 @@
 
 set -euo pipefail
 
-FCITX_THEME="nyxmellow"
 FCITX_THEMES_DIR="$HOME/.local/share/fcitx5/themes"
 FCITX_THEME_DIR="$FCITX_THEMES_DIR/$FCITX_THEME"
 FCITX_TEMPLATE_DIR="$FCITX_THEME_DIR/templates"

--- a/lib/greeter.sh
+++ b/lib/greeter.sh
@@ -10,7 +10,6 @@
 
 set -euo pipefail
 
-GREETER_PKG="noctalia-greeter"
 GREETER_SESSION_BIN="noctalia-greeter-session"
 GREETER_ETC_CFG="/etc/greetd/config.toml"
 GREETER_STATE_DIR="/var/lib/$GREETER_PKG"

--- a/v2/niri/scripts/niri-scratch-toggle.sh
+++ b/v2/niri/scripts/niri-scratch-toggle.sh
@@ -103,8 +103,6 @@ case "$TARGET_APP" in
     wallpaper|wallpapers|"wallpaper-picker"|WallpaperPicker|*wallpaper-picker.py)
         if [ -f "$HOME/.config/niri/scripts/wallpaper-picker.py" ]; then
             niri msg action spawn -- "$HOME/.config/niri/scripts/wallpaper-picker.py"
-        elif [ -f "${BASH_SOURCE%/*}/wallpaper-picker.py" ]; then
-            niri msg action spawn -- "${BASH_SOURCE%/*}/wallpaper-picker.py"
         else
             niri msg action spawn -- wallpaper-picker.py
         fi

--- a/v2/niri/scripts/wallpaper_picker/backend.py
+++ b/v2/niri/scripts/wallpaper_picker/backend.py
@@ -1,20 +1,14 @@
-"""
-NyxNiri Wallpaper Picker Backend Engine
-Executes wallpaper switching for static images and live video wallpapers, synchronized with Noctalia & mpvpaper plugin state.
-"""
-
 import os
 import sys
 import json
 import random
 import subprocess
+import time
 
 STATE_DIR = os.path.expanduser("~/.local/state/noctalia/mpvpaper")
 ASSIGNMENTS_FILE = os.path.join(STATE_DIR, "assignments.json")
 
-
 def _write_mpvpaper_assignments(assignments: dict):
-    """Write mpvpaper assignments atomically to synchronize with Noctalia's mpvpaper service."""
     try:
         os.makedirs(STATE_DIR, exist_ok=True)
         tmp_file = f"{ASSIGNMENTS_FILE}.tmp.{os.getpid()}"
@@ -28,52 +22,56 @@ def _write_mpvpaper_assignments(assignments: dict):
     except Exception as e:
         print(f"Warning: Failed to update mpvpaper assignments: {e}", file=sys.stderr)
 
+def _wait_for_process_exit(name: str, timeout: float = 3.0):
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        try:
+            result = subprocess.run(
+                ["pgrep", "-x", name],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=1
+            )
+            if result.returncode != 0:
+                return True
+        except Exception:
+            return True
+        time.sleep(0.05)
+    return False
+
+def _clear_mpvpaper():
+    try:
+        subprocess.run(
+            ["noctalia", "msg", "plugin", "noctalia/mpvpaper:service", "all", "clear-all"],
+            stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=2
+        )
+    except Exception:
+        pass
+    _write_mpvpaper_assignments({})
+    subprocess.run(["pkill", "-x", "mpvpaper"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    _wait_for_process_exit("mpvpaper", timeout=2.0)
 
 def apply_static_wallpaper(path: str) -> bool:
-    """Apply static wallpaper, clear mpvpaper video assignments, and restore host wallpaper rendering."""
     try:
-        # 1. Notify Noctalia's mpvpaper service to clear assignments and re-enable static wallpaper layer
-        try:
-            subprocess.run(
-                ["noctalia", "msg", "plugin", "noctalia/mpvpaper:service", "all", "clear-all"],
-                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=2
-            )
-        except Exception:
-            pass
-
-        # 2. Clear mpvpaper assignments file directly as fallback
-        _write_mpvpaper_assignments({})
-
-        # 3. Terminate any running mpvpaper instances
-        subprocess.run(["pkill", "-x", "mpvpaper"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-
-        # 4. Apply static wallpaper via Noctalia IPC to trigger full-system theme extraction and layer restore
+        _clear_mpvpaper()
         subprocess.Popen(["noctalia", "msg", "wallpaper-set", path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         return True
     except Exception as e:
         print(f"Error applying static wallpaper: {e}", file=sys.stderr)
         return False
 
-
 def apply_dynamic_wallpaper(video_path: str, thumb_path: str = None) -> bool:
-    """Apply dynamic video wallpaper via mpvpaper and synchronize Noctalia Material You palette."""
     try:
-        # 1. Terminate existing mpvpaper instances
-        subprocess.run(["pkill", "-x", "mpvpaper"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-
-        # 2. Update assignments so Noctalia's plugin and hooks recognize the active video
+        _clear_mpvpaper()
         _write_mpvpaper_assignments({"*": video_path})
-
-        # 3. If thumbnail is available, set it as Noctalia wallpaper for instant theme sync
         if thumb_path and os.path.isfile(thumb_path):
-            subprocess.run(["noctalia", "msg", "wallpaper-set", thumb_path], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-
-        # 4. Launch mpvpaper with Noctalia lua sync hook and auto-pause
+            subprocess.run(
+                ["noctalia", "msg", "wallpaper-set", thumb_path],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, timeout=2
+            )
+        time.sleep(0.15)
         hook_script = os.path.expanduser("~/.config/noctalia/mpv-hook.lua")
         mpv_opts = "loop-file=inf panscan=1.0 no-audio hwdec=auto"
         if os.path.isfile(hook_script):
             mpv_opts += f" --script={hook_script}"
-
         cmd = ["mpvpaper", "--auto-pause", "-o", mpv_opts, "*", video_path]
         subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         return True
@@ -81,17 +79,13 @@ def apply_dynamic_wallpaper(video_path: str, thumb_path: str = None) -> bool:
         print(f"Error applying live wallpaper: {e}", file=sys.stderr)
         return False
 
-
 def apply_wallpaper(item) -> bool:
-    """Polymorphic wallpaper application dispatcher."""
     if item.is_video:
         return apply_dynamic_wallpaper(item.path, item.thumb_path)
     else:
         return apply_static_wallpaper(item.path)
 
-
 def apply_random_wallpaper(items: list):
-    """Pick and apply a random wallpaper from the provided item collection."""
     if not items:
         return None
     target = random.choice(items)

--- a/v2/niri/scripts/wallpaper_picker/lock.py
+++ b/v2/niri/scripts/wallpaper_picker/lock.py
@@ -1,16 +1,10 @@
-"""
-NyxNiri Wallpaper Picker Single-Instance & True-Toggle Locking Engine
-Ensures atomic single-instance execution. If another instance is running, sends SIGTERM to toggle-close it.
-"""
-
 import os
 import sys
 import signal
 import fcntl
-
+import time
 
 def acquire_instance_lock(lock_path: str, pid_path: str) -> int:
-    """Acquire single-instance file lock. Toggle-close existing instance if detected."""
     lock_fd = None
     try:
         lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
@@ -21,6 +15,7 @@ def acquire_instance_lock(lock_path: str, pid_path: str) -> int:
                 os.close(lock_fd)
             except Exception:
                 pass
+            lock_fd = None
         if os.path.isfile(pid_path):
             try:
                 with open(pid_path, "r") as pf:
@@ -28,19 +23,30 @@ def acquire_instance_lock(lock_path: str, pid_path: str) -> int:
                 os.kill(old_pid, signal.SIGTERM)
             except Exception:
                 pass
-        sys.exit(0)
-
+        for _ in range(20):
+            time.sleep(0.025)
+            try:
+                lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
+                fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                break
+            except (BlockingIOError, OSError):
+                if lock_fd is not None:
+                    try:
+                        os.close(lock_fd)
+                    except Exception:
+                        pass
+                    lock_fd = None
+                continue
+        if lock_fd is None:
+            sys.exit(0)
     try:
         with open(pid_path, "w") as pf:
             pf.write(str(os.getpid()))
     except Exception:
         pass
-
     return lock_fd
 
-
 def release_instance_lock(lock_fd: int, pid_path: str):
-    """Release file lock and clean up PID file."""
     try:
         if os.path.isfile(pid_path):
             os.remove(pid_path)

--- a/v2/niri/scripts/wallpaper_picker/window.py
+++ b/v2/niri/scripts/wallpaper_picker/window.py
@@ -1,8 +1,3 @@
-"""
-NyxNiri Wallpaper Picker Main Window & Interaction Controller
-Stateless, event-driven Wayland Layer-Shell dialog with continuous smooth scrolling, spring physics, and pure M3E design.
-"""
-
 import sys
 import os
 import math
@@ -12,7 +7,6 @@ gi.require_version("GtkLayerShell", "0.1")
 gi.require_version("Gdk", "3.0")
 gi.require_version("Pango", "1.0")
 from gi.repository import Gtk, Gdk, GtkLayerShell, GLib, Pango
-
 from .physics import Spring
 from .palette import load_material_palette
 from .lock import release_instance_lock
@@ -28,23 +22,15 @@ from .renderer import (
     draw_category_chips, draw_card, draw_scrollbar
 )
 
-
 class WallpaperPickerWindow(Gtk.Window):
-    """Main M3E GtkLayerShell Wallpaper Picker Window with Pro-Grade Search Input."""
-
     def __init__(self, lock_fd: int = None, pid_path: str = None):
         super().__init__(type=Gtk.WindowType.TOPLEVEL)
-
         self.lock_fd = lock_fd
         self.pid_path = pid_path
         self.palette = load_material_palette()
-
-        # Scanner and data
         self.scanner = WallpaperScanner(on_thumb_ready_cb=self.on_thumb_ready)
         self.scanner.scan()
         self.current_wp_path = self.scanner.get_current_wallpaper()
-
-        # View & Search state
         self.active_cat_idx = 0
         self.hover_cat_idx = None
         self.hovered_card_idx = None
@@ -54,44 +40,33 @@ class WallpaperPickerWindow(Gtk.Window):
         self.search_active = True
         self.cursor_time = 0.0
         self.is_dismissing = False
-
+        self._suppress_hover = False
         self.chip_boxes = []
         self.card_boxes = []
         self.search_box = None
         self.clear_box = None
-
-        # High-Fidelity Motion Springs Matrix
         self.target_scroll_y = 0.0
         self.scroll_spring = Spring(0.0, omega=26.0, zeta=0.92)
         self.entry_spring = Spring(0.0, omega=18.0, zeta=0.82)
         self.card_springs = {}
-
-        # Native Wayland CJK IME Context (Fcitx5 / IBus)
         self.im_context = Gtk.IMMulticontext()
         self.im_context.set_use_preedit(True)
         self.im_context.connect("commit", self.on_im_commit)
         self.im_context.connect("preedit-changed", lambda ctx: self._request_frame())
-
-        # FrameClock callback & cursor blink timer
         self.tick_callback_id = None
         self.cursor_timer_id = None
         self.last_frame_time = 0
-
-        # Layer Shell Setup
         GtkLayerShell.init_for_window(self)
         GtkLayerShell.set_layer(self, GtkLayerShell.Layer.OVERLAY)
         GtkLayerShell.set_keyboard_mode(self, GtkLayerShell.KeyboardMode.EXCLUSIVE)
         GtkLayerShell.set_exclusive_zone(self, -1)
-
         for edge in (GtkLayerShell.Edge.LEFT, GtkLayerShell.Edge.RIGHT, GtkLayerShell.Edge.TOP, GtkLayerShell.Edge.BOTTOM):
             GtkLayerShell.set_anchor(self, edge, True)
             GtkLayerShell.set_margin(self, edge, 0)
-
         self.set_app_paintable(True)
         visual = self.get_screen().get_rgba_visual()
         if visual:
             self.set_visual(visual)
-
         self.add_events(
             Gdk.EventMask.POINTER_MOTION_MASK
             | Gdk.EventMask.BUTTON_PRESS_MASK
@@ -102,7 +77,6 @@ class WallpaperPickerWindow(Gtk.Window):
             | Gdk.EventMask.KEY_RELEASE_MASK
             | Gdk.EventMask.STRUCTURE_MASK
         )
-
         self.connect("realize", self.on_realize)
         self.connect("draw", self.on_draw)
         self.connect("motion-notify-event", self.on_motion_notify)
@@ -111,7 +85,6 @@ class WallpaperPickerWindow(Gtk.Window):
         self.connect("key-press-event", self.on_key_press)
         self.connect("delete-event", lambda w, e: (self.dismiss_window(), True)[1])
         self.connect("destroy", lambda w: Gtk.main_quit())
-
         self.open_window()
         self.scanner.load_thumbnails_async()
 
@@ -121,7 +94,6 @@ class WallpaperPickerWindow(Gtk.Window):
             self.im_context.set_client_window(gdk_window)
 
     def on_thumb_ready(self, item):
-        """Called when a background thumbnail is ready to trigger instant visual repaint."""
         self.queue_draw()
         self._request_frame()
 
@@ -137,6 +109,7 @@ class WallpaperPickerWindow(Gtk.Window):
     def open_window(self):
         self.palette = load_material_palette()
         self.is_dismissing = False
+        self._suppress_hover = False
         self.entry_spring.omega = 16.0
         self.entry_spring.zeta = 0.76
         self.entry_spring.current = 0.0
@@ -144,10 +117,8 @@ class WallpaperPickerWindow(Gtk.Window):
         self.entry_spring.velocity = 0.0
         self.search_active = True
         self.cursor_idx = len(self.search_query)
-
         if self.cursor_timer_id is None:
             self.cursor_timer_id = GLib.timeout_add(500, self._on_cursor_blink_timer)
-
         self.show_all()
         self.present()
         self.im_context.focus_in()
@@ -184,23 +155,16 @@ class WallpaperPickerWindow(Gtk.Window):
         frame_time = frame_clock.get_frame_time()
         dt = 0.016 if self.last_frame_time == 0 else (frame_time - self.last_frame_time) / 1_000_000.0
         self.last_frame_time = frame_time
-
         still_animating = False
-
         if self.entry_spring.update(dt):
             still_animating = True
-
         if self.is_dismissing and self.entry_spring.current <= 0.005:
             self._finish_dismiss()
             self.tick_callback_id = None
             return GLib.SOURCE_REMOVE
-
-        # Update smooth scrolling spring
         self.scroll_spring.target = self.target_scroll_y
         if self.scroll_spring.update(dt):
             still_animating = True
-
-        # Update active card elevation springs
         active_keys = list(self.card_springs.keys())
         for idx in active_keys:
             is_hl = (self.hovered_card_idx == idx or self.keyboard_selected_idx == idx) and not self.is_dismissing
@@ -209,52 +173,43 @@ class WallpaperPickerWindow(Gtk.Window):
                 still_animating = True
             elif not is_hl and abs(self.card_springs[idx].current) < 0.005:
                 del self.card_springs[idx]
-
         self.queue_draw()
-
         if not still_animating:
             self.tick_callback_id = None
             return GLib.SOURCE_REMOVE
-
         return GLib.SOURCE_CONTINUE
 
     def get_current_items(self) -> list:
-        """Get filtered wallpaper items based on active category and search query."""
         if self.search_query.strip():
             q = self.search_query.strip().lower()
             return [it for it in self.scanner.items if q in it.title.lower() or q in it.filename.lower()]
-
         if 0 <= self.active_cat_idx < len(self.scanner.categories):
             cat_name = self.scanner.categories[self.active_cat_idx]
             return self.scanner.category_items.get(cat_name, [])
         return self.scanner.items
 
     def select_and_apply(self, item):
-        """Apply selected wallpaper and dismiss."""
+        self._suppress_hover = True
+        self.hovered_card_idx = None
         apply_wallpaper(item)
         self.dismiss_window()
 
     def get_max_scroll_y(self) -> float:
-        """Calculate maximum vertical scroll offset for current item collection."""
         items = self.get_current_items()
         total_rows = math.ceil(len(items) / GRID_COLS)
         total_h = total_rows * (CARD_HEIGHT + GAP_Y)
         return max(0.0, total_h - GRID_VIEWPORT_H + 16.0)
 
     def scroll_to_make_visible(self, item_idx: int):
-        """Adjust target_scroll_y to ensure the focused card is visible within the viewport."""
         row = item_idx // GRID_COLS
         card_top = row * (CARD_HEIGHT + GAP_Y)
         card_bottom = card_top + CARD_HEIGHT
-
         curr_view_top = self.target_scroll_y
         curr_view_bottom = curr_view_top + GRID_VIEWPORT_H
-
         if card_top < curr_view_top:
             self.target_scroll_y = card_top
         elif card_bottom > curr_view_bottom:
             self.target_scroll_y = card_bottom - GRID_VIEWPORT_H + 16.0
-
         max_scroll = self.get_max_scroll_y()
         self.target_scroll_y = max(0.0, min(max_scroll, self.target_scroll_y))
         self._request_frame()
@@ -263,31 +218,21 @@ class WallpaperPickerWindow(Gtk.Window):
         entry_val = max(0.0, min(1.0, self.entry_spring.current))
         if entry_val <= 0.001:
             return False
-
         win_w = self.get_allocated_width() or 1920
         win_h = self.get_allocated_height() or 1080
-
-        # Hermite smoothstep cubic curve for silky non-linear alpha & spatial scale
         t = entry_val
         alpha = t * t * (3.0 - 2.0 * t)
         scale = 0.96 + 0.04 * t
-
         dialog_w = min(WIN_WIDTH, win_w - 40.0)
         dialog_h = min(WIN_HEIGHT, win_h - 40.0)
         dialog_x = (win_w - dialog_w) / 2.0
         dialog_y = (win_h - dialog_h) / 2.0 + (1.0 - t) * 12.0
-
-        # Render dialog in an isolated group with smooth centered micro-scale transform
         cr.save()
         cr.translate(win_w / 2.0, win_h / 2.0)
         cr.scale(scale, scale)
         cr.translate(-win_w / 2.0, -win_h / 2.0)
         cr.push_group()
-
-        # Dialog Frosted Glass Container with Multi-Tier Diffuse Shadow
         draw_dialog_container(cr, dialog_x, dialog_y, dialog_w, dialog_h, WIN_RADIUS, self.palette)
-
-        # Top Header & Pro-Grade Search Pill
         all_count = len(self.scanner.items)
         self.search_box, self.clear_box, cursor_rect = draw_header(
             cr, dialog_x, dialog_y, dialog_w,
@@ -299,14 +244,10 @@ class WallpaperPickerWindow(Gtk.Window):
             palette=self.palette,
             create_layout_fn=self.create_pango_layout
         )
-
-        # Sync Wayland CJK IME cursor location precisely under caret
         if self.search_active and cursor_rect:
             rect = Gdk.Rectangle()
             rect.x, rect.y, rect.width, rect.height = int(cursor_rect[0]), int(cursor_rect[1]), int(cursor_rect[2]), int(cursor_rect[3])
             self.im_context.set_cursor_location(rect)
-
-        # Category Chips
         chips_y = dialog_y + 70.0
         self.chip_boxes = draw_category_chips(
             cr, dialog_x, chips_y, dialog_w,
@@ -316,43 +257,31 @@ class WallpaperPickerWindow(Gtk.Window):
             palette=self.palette,
             create_layout_fn=self.create_pango_layout
         )
-
-        # Continuous Scrollable Card Grid
         grid_x = dialog_x + 32.0
         grid_y = dialog_y + GRID_VIEWPORT_Y
         grid_w = dialog_w - 64.0
         grid_h = GRID_VIEWPORT_H
-
         scroll_y = self.scroll_spring.current
         items = self.get_current_items()
         max_scroll_y = self.get_max_scroll_y()
-
-        # Viewport clipping with safe padding
         cr.save()
         cr.rectangle(dialog_x + 16.0, grid_y, dialog_w - 32.0, grid_h)
         cr.clip()
-
         self.card_boxes = []
-
         for idx, item in enumerate(items):
             row = idx // GRID_COLS
             col = idx % GRID_COLS
             cx = grid_x + col * (CARD_WIDTH + GAP_X)
             cy = grid_y + 8.0 + row * (CARD_HEIGHT + GAP_Y) - scroll_y
-
             self.card_boxes.append((cx, cy, CARD_WIDTH, CARD_HEIGHT))
-
-            # Render visible cards
             if cy + CARD_HEIGHT >= grid_y - 20.0 and cy <= grid_y + grid_h + 20.0:
                 is_cur = (item.path == self.current_wp_path)
                 is_active = (self.keyboard_selected_idx == idx)
                 is_hover = (self.hovered_card_idx == idx)
-
                 if is_active or is_hover:
                     if idx not in self.card_springs:
                         self.card_springs[idx] = Spring(0.0, omega=26.0, zeta=0.92)
                 hover_val = self.card_springs[idx].current if idx in self.card_springs else 0.0
-
                 draw_card(
                     cr, cx, cy, CARD_WIDTH, CARD_HEIGHT, item,
                     is_active=is_active,
@@ -362,18 +291,12 @@ class WallpaperPickerWindow(Gtk.Window):
                     palette=self.palette,
                     create_layout_fn=self.create_pango_layout
                 )
-
         cr.restore()
-
-        # Minimalist Scrollbar Indicator
         sb_x = dialog_x + dialog_w - 20.0
         draw_scrollbar(cr, sb_x, grid_y, grid_h, scroll_y, max_scroll_y, self.palette)
-
-        # Composite the entire dialog group seamlessly with Hermite cubic alpha
         cr.pop_group_to_source()
         cr.paint_with_alpha(alpha)
         cr.restore()
-
         return False
 
     def on_im_commit(self, im_context, text):
@@ -386,41 +309,33 @@ class WallpaperPickerWindow(Gtk.Window):
         self._request_frame()
 
     def on_motion_notify(self, widget, event):
-        if self.is_dismissing:
+        if self.is_dismissing or self._suppress_hover:
             return True
-
         mx, my = event.x, event.y
-
-        # Check Category Chips
         new_hover_cat = None
         for idx, (bx, by, bw, bh) in enumerate(self.chip_boxes):
             if bx <= mx <= bx + bw and by <= my <= by + bh:
                 new_hover_cat = idx
                 break
-
         if new_hover_cat != self.hover_cat_idx:
             self.hover_cat_idx = new_hover_cat
             self._request_frame()
-
-        # Check Cards
         new_hover_card = None
         items = self.get_current_items()
         for idx, (bx, by, bw, bh) in enumerate(self.card_boxes):
             if idx < len(items) and bx <= mx <= bx + bw and by <= my <= by + bh:
                 new_hover_card = idx
                 break
-
         if new_hover_card != self.hovered_card_idx:
             self.hovered_card_idx = new_hover_card
+            if new_hover_card is not None:
+                self.keyboard_selected_idx = new_hover_card
             self._request_frame()
-
         return True
 
     def on_button_press(self, widget, event):
         if self.is_dismissing:
             return True
-
-        # Right-click -> Dismiss or clear search
         if event.button in (2, 3):
             if self.search_query:
                 self.search_query = ""
@@ -431,12 +346,8 @@ class WallpaperPickerWindow(Gtk.Window):
             else:
                 self.dismiss_window()
             return True
-
-        # Left-click
         if event.button == 1:
             mx, my = event.x, event.y
-
-            # 1. Clicked Clear '×' button
             if self.clear_box:
                 cx, cy, cw, ch = self.clear_box
                 if cx <= mx <= cx + cw and cy <= my <= cy + ch:
@@ -447,8 +358,6 @@ class WallpaperPickerWindow(Gtk.Window):
                     self.keyboard_selected_idx = 0
                     self._request_frame()
                     return True
-
-            # 2. Clicked Search Pill
             if self.search_box:
                 sx, sy, sw, sh = self.search_box
                 if sx <= mx <= sx + sw and sy <= my <= sy + sh:
@@ -456,8 +365,6 @@ class WallpaperPickerWindow(Gtk.Window):
                     self.cursor_idx = len(self.search_query)
                     self._request_frame()
                     return True
-
-            # 3. Clicked category chip
             for idx, (bx, by, bw, bh) in enumerate(self.chip_boxes):
                 if bx <= mx <= bx + bw and by <= my <= by + bh:
                     self.active_cat_idx = idx
@@ -465,15 +372,11 @@ class WallpaperPickerWindow(Gtk.Window):
                     self.keyboard_selected_idx = 0
                     self._request_frame()
                     return True
-
-            # 4. Clicked card
             items = self.get_current_items()
             for idx, (bx, by, bw, bh) in enumerate(self.card_boxes):
                 if idx < len(items) and bx <= mx <= bx + bw and by <= my <= by + bh:
                     self.select_and_apply(items[idx])
                     return True
-
-            # 5. Clicked outside dialog -> dismiss
             win_w = self.get_allocated_width() or 1920
             win_h = self.get_allocated_height() or 1080
             dialog_w = min(WIN_WIDTH, win_w - 40.0)
@@ -483,19 +386,14 @@ class WallpaperPickerWindow(Gtk.Window):
             if not (dialog_x <= mx <= dialog_x + dialog_w and dialog_y <= my <= dialog_y + dialog_h):
                 self.dismiss_window()
                 return True
-
         return False
 
     def on_scroll(self, widget, event):
-        """Handle smooth continuous scrolling for both touchpad and mouse wheel."""
         if self.is_dismissing:
             return False
-
         max_scroll_y = self.get_max_scroll_y()
         if max_scroll_y <= 0:
             return False
-
-        # 1. High-precision Touchpad & Smooth Wheel
         if event.direction == Gdk.ScrollDirection.SMOOTH:
             success, dx, dy = event.get_scroll_deltas()
             if success:
@@ -503,8 +401,6 @@ class WallpaperPickerWindow(Gtk.Window):
                 self.target_scroll_y = max(0.0, min(max_scroll_y, self.target_scroll_y))
                 self._request_frame()
                 return True
-
-        # 2. Discrete Mouse Wheel
         elif event.direction == Gdk.ScrollDirection.DOWN:
             self.target_scroll_y += 120.0
             self.target_scroll_y = max(0.0, min(max_scroll_y, self.target_scroll_y))
@@ -515,21 +411,15 @@ class WallpaperPickerWindow(Gtk.Window):
             self.target_scroll_y = max(0.0, min(max_scroll_y, self.target_scroll_y))
             self._request_frame()
             return True
-
         return False
 
     def on_key_press(self, widget, event):
         if self.is_dismissing:
             return True
-
         keyval = event.keyval
         ctrl = bool(event.state & Gdk.ModifierType.CONTROL_MASK)
-
-        # 1. IME Processing
         if self.im_context.filter_keypress(event):
             return True
-
-        # 2. Ctrl Shortcuts
         if ctrl:
             if keyval in (Gdk.KEY_r, Gdk.KEY_R):
                 items = self.get_current_items()
@@ -570,8 +460,6 @@ class WallpaperPickerWindow(Gtk.Window):
                 self.target_scroll_y = 0.0
                 self._request_frame()
                 return True
-
-        # 3. Escape
         if keyval == Gdk.KEY_Escape:
             if self.search_query:
                 self.search_query = ""
@@ -581,28 +469,59 @@ class WallpaperPickerWindow(Gtk.Window):
             else:
                 self.dismiss_window()
             return True
-
-        # 4. Cursor Left / Right / Home / End
         if keyval == Gdk.KEY_Left:
-            if self.cursor_idx > 0:
-                self.cursor_idx -= 1
+            if self.search_active and self.search_query:
+                if self.cursor_idx > 0:
+                    self.cursor_idx -= 1
+                    self._request_frame()
+                return True
+            items = self.get_current_items()
+            num_items = len(items)
+            if num_items == 0:
+                return True
+            col = self.keyboard_selected_idx % GRID_COLS
+            if col > 0 and self.keyboard_selected_idx - 1 >= 0:
+                self.keyboard_selected_idx -= 1
+                self.scroll_to_make_visible(self.keyboard_selected_idx)
                 self._request_frame()
             return True
         elif keyval == Gdk.KEY_Right:
-            if self.cursor_idx < len(self.search_query):
-                self.cursor_idx += 1
+            if self.search_active and self.search_query:
+                if self.cursor_idx < len(self.search_query):
+                    self.cursor_idx += 1
+                    self._request_frame()
+                return True
+            items = self.get_current_items()
+            num_items = len(items)
+            if num_items == 0:
+                return True
+            col = self.keyboard_selected_idx % GRID_COLS
+            if col < GRID_COLS - 1 and self.keyboard_selected_idx + 1 < num_items:
+                self.keyboard_selected_idx += 1
+                self.scroll_to_make_visible(self.keyboard_selected_idx)
                 self._request_frame()
             return True
         elif keyval == Gdk.KEY_Home:
-            self.cursor_idx = 0
+            if self.search_active and self.search_query:
+                self.cursor_idx = 0
+                self._request_frame()
+                return True
+            self.keyboard_selected_idx = 0
+            self.scroll_to_make_visible(0)
             self._request_frame()
             return True
         elif keyval == Gdk.KEY_End:
-            self.cursor_idx = len(self.search_query)
-            self._request_frame()
+            if self.search_active and self.search_query:
+                self.cursor_idx = len(self.search_query)
+                self._request_frame()
+                return True
+            items = self.get_current_items()
+            num_items = len(items)
+            if num_items > 0:
+                self.keyboard_selected_idx = num_items - 1
+                self.scroll_to_make_visible(self.keyboard_selected_idx)
+                self._request_frame()
             return True
-
-        # 5. Backspace & Delete at Cursor Index
         if keyval == Gdk.KEY_BackSpace:
             if self.cursor_idx > 0:
                 self.cursor_time = 0.0
@@ -614,7 +533,6 @@ class WallpaperPickerWindow(Gtk.Window):
             elif not self.search_query:
                 self.dismiss_window()
             return True
-
         if keyval == Gdk.KEY_Delete:
             if self.cursor_idx < len(self.search_query):
                 self.cursor_time = 0.0
@@ -622,8 +540,6 @@ class WallpaperPickerWindow(Gtk.Window):
                 self.target_scroll_y = 0.0
                 self._request_frame()
             return True
-
-        # 6. Tab / Shift+Tab for Category Chips
         if keyval in (Gdk.KEY_Tab, Gdk.KEY_ISO_Left_Tab):
             step = -1 if bool(event.state & Gdk.ModifierType.SHIFT_MASK) or keyval == Gdk.KEY_ISO_Left_Tab else 1
             self.active_cat_idx = (self.active_cat_idx + step) % len(self.scanner.categories)
@@ -631,31 +547,34 @@ class WallpaperPickerWindow(Gtk.Window):
             self.keyboard_selected_idx = 0
             self._request_frame()
             return True
-
-        # 7. Navigation (Arrow Down / Up -> Select within Card Grid)
         items = self.get_current_items()
         num_items = len(items)
-
         if keyval == Gdk.KEY_Down:
             if self.keyboard_selected_idx + GRID_COLS < num_items:
                 self.keyboard_selected_idx += GRID_COLS
                 self.scroll_to_make_visible(self.keyboard_selected_idx)
+                self._request_frame()
+            elif num_items > 0:
+                self.keyboard_selected_idx = num_items - 1
+                self.scroll_to_make_visible(self.keyboard_selected_idx)
+                self._request_frame()
             return True
         elif keyval == Gdk.KEY_Up:
             if self.keyboard_selected_idx >= GRID_COLS:
                 self.keyboard_selected_idx -= GRID_COLS
                 self.scroll_to_make_visible(self.keyboard_selected_idx)
+                self._request_frame()
+            else:
+                self.keyboard_selected_idx = 0
+                self.scroll_to_make_visible(0)
+                self._request_frame()
             return True
-
-        # 8. Enter -> Apply selected wallpaper
         if keyval in (Gdk.KEY_Return, Gdk.KEY_KP_Enter):
             if 0 <= self.keyboard_selected_idx < num_items:
                 self.select_and_apply(items[self.keyboard_selected_idx])
             elif num_items > 0:
                 self.select_and_apply(items[0])
             return True
-
-        # 9. Printable Text Typing (Inserted at cursor_idx)
         if 32 <= keyval <= 126 and not ctrl:
             char = chr(keyval)
             self.cursor_time = 0.0
@@ -665,5 +584,4 @@ class WallpaperPickerWindow(Gtk.Window):
             self.keyboard_selected_idx = 0
             self._request_frame()
             return True
-
         return False

--- a/v2/noctalia/mpvpaper-sync.sh
+++ b/v2/noctalia/mpvpaper-sync.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -uo pipefail
 # Hook to synchronize mpvpaper's video wallpaper with Noctalia's native wallpaper and theme.
 
 # Check dependencies
@@ -12,7 +13,7 @@ done
 ASSIGNMENTS_FILE="$HOME/.local/state/noctalia/mpvpaper/assignments.json"
 
 # Signal trap for clean termination
-trap 'exit 0' INT TERM EXIT
+trap 'exit 0' INT TERM
 
 process_assignments() {
     local VIDEO_PATH THUMB_NAME THUMB_PATH CURRENT_WP

--- a/v2/noctalia/wallpaper-hook.sh
+++ b/v2/noctalia/wallpaper-hook.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -uo pipefail
 
 # Ensure noctalia is available
 if ! command -v noctalia >/dev/null 2>&1; then
@@ -31,7 +32,7 @@ if [[ -n "$WP" && -f "$WP" && "$WP" =~ \.(mp4|webm|mkv|mov|gif)$ ]]; then
     # Generate thumbnail
     if ffmpeg -y -i "$WP" -ss 00:00:01 -vframes 1 "$THUMB_PATH" 2>/dev/null; then
         # Set the thumbnail as wallpaper to extract colors and provide a static background
-        noctalia msg wallpaper-set "$THUMB_PATH" 2>/dev/null
+        noctalia msg wallpaper-set "$THUMB_PATH" 2>/dev/null || true
     else
         echo "Error: ffmpeg failed to extract thumbnail from $WP" >> "$LOG_FILE"
     fi


### PR DESCRIPTION
Closes #14, Closes #13

## #14 wallpaper-picker: 重复触发、悬停状态与方向键网格导航不完整

- **lock.py**: SIGTERM 后添加轮询等待循环（最多 500ms），确保旧实例真正释放锁后再继续，消除竞态窗口导致的重复触发
- **window.py**: 新增 `_suppress_hover` 标志，壁纸应用期间屏蔽鼠标 motion 事件，防止 dismiss 动画过程中悬停状态错乱
- **window.py**: 搜索框为空时 Left/Right 实现网格左右导航（按列移动，边界检测）
- **window.py**: Down/Up 到达网格边缘时 clamp 到首/末项，不再越界跳过
- **window.py**: Home/End 新增网格跳首/跳尾逻辑

## #13 fix(wallpaper): 动态壁纸无法播放或异常停止

- **backend.py**: 提取统一 `_clear_mpvpaper()` 函数，先通知 Noctalia 插件清除 → 写空 assignments → kill mpvpaper → 等待退出
- **backend.py**: 新增 `_wait_for_process_exit()` 轮询循环（2s 超时），确保旧 mpvpaper 进程完全退出后再启动新实例
- **backend.py**: 写完 assignments 后增加 150ms 延迟，让 Noctalia inotify watcher 处理完文件变更再启动 mpvpaper

## Code audit fixes

- deploy.sh: hardcoded `noctalia-config.toml` 替换为 `${THEME_ENGINE}-config.toml`
- deploy.sh: `export VAR=$(mktemp)` 拆分为两行（符合 AGENTS.md 规范）
- greeter.sh: 移除重复的 `GREETER_PKG` 硬编码（core.sh 已 export）
- fcitx.sh: 移除重复的 `FCITX_THEME` 硬编码（core.sh 已 export）
- wallpaper-hook.sh: 添加 `set -uo pipefail`，`wallpaper-set` 添加 `|| true`
- mpvpaper-sync.sh: 添加 `set -uo pipefail`，移除 trap 中的 EXIT 以保留退出码
- backup.sh: `cat note.txt` 替换为 `head -n1` 防止多行显示异常
- niri-scratch-toggle.sh: 移除不可靠的 `BASH_SOURCE` fallback 路径
- install.sh: `rm -rf` 路径检查增加 `$HOME` 前缀限制