### PR TITLE
feat: TUI 增强、内置 KDL 解析器、monitor.kdl 竞态修复

### DIFF
--- a/nyxniri/cli.py
+++ b/nyxniri/cli.py
@@ -62,9 +62,11 @@ from nyxniri.tui import (
     CheckboxList,
     MenuItem,
     Menu,
+    Spinner,
     pad_display,
     press_any_key,
     prompt_confirm,
+    read_line,
     select_language,
 )
 
@@ -204,17 +206,17 @@ def install_configs_workflow(mode: str = "full") -> bool:
     # 1. Deps
     if mode == "full":
         cur_step += 1
-        print(msg("install_step_deps", f"{cur_step}/{steps}"))
-        missing = get_missing_deps()
-        if missing:
-            install_selected_deps(missing)
+        with Spinner(msg("install_step_deps", f"{cur_step}/{steps}")):
+            missing = get_missing_deps()
+            if missing:
+                install_selected_deps(missing)
 
     # 2. Configs
     cur_step += 1
-    print(msg("install_step_configs", f"{cur_step}/{steps}"))
     preserved_log: List[str] = []
     if chosen_configs:
-        failed_items = deploy_selected_configs(do_backup=do_backup, items_to_deploy=chosen_configs, preserved_log=preserved_log)
+        with Spinner(msg("install_step_configs", f"{cur_step}/{steps}")):
+            failed_items = deploy_selected_configs(do_backup=do_backup, items_to_deploy=chosen_configs, preserved_log=preserved_log)
         if failed_items:
             render_completion_screen(
                 mode=mode,
@@ -227,20 +229,20 @@ def install_configs_workflow(mode: str = "full") -> bool:
     # 3. Wallpapers (always run — at least syncs offline fallback wallpapers)
     wallpaper_result = None
     cur_step += 1
-    print(msg("install_step_wallpapers", f"{cur_step}/{steps}"))
-    wallpaper_result = deploy_wallpapers(do_download=do_wallpapers)
+    with Spinner(msg("install_step_wallpapers", f"{cur_step}/{steps}")):
+        wallpaper_result = deploy_wallpapers(do_download=do_wallpapers)
 
     # 4. Fcitx5
     if do_fcitx:
         cur_step += 1
-        print(msg("install_step_fcitx", f"{cur_step}/{steps}"))
-        fcitx_install()
+        with Spinner(msg("install_step_fcitx", f"{cur_step}/{steps}")):
+            fcitx_install()
 
     # 5. Greeter
     if do_greeter:
         cur_step += 1
-        print(msg("install_step_greeter", f"{cur_step}/{steps}"))
-        greeter_install()
+        with Spinner(msg("install_step_greeter", f"{cur_step}/{steps}")):
+            greeter_install()
 
     # Completion
     render_completion_screen(
@@ -362,12 +364,11 @@ def snapshot_menu_loop() -> None:
             MenuItem(label=msg("snapshot_sub_rollback")),
             MenuItem(label=msg("snapshot_sub_back"), style="subtle"),
         ]
-        menu = Menu("snapshot_menu_title", items, hint_key="submenu_hint")
+        menu = Menu("snapshot_menu_title", items, hint_key="submenu_hint",
+                    breadcrumb=["NyxNiri", msg("snapshot_menu_title").strip()])
         choice = menu.run()
         if choice == 0:
-            sys.stdout.write(msg("snapshot_note_prompt"))
-            sys.stdout.flush()
-            note = sys.stdin.readline().strip()
+            note = read_line(msg("snapshot_note_prompt"))
             backup_configs(note=note, interactive=True)
             press_any_key()
         elif choice == 1:
@@ -391,7 +392,8 @@ def greeter_menu_loop() -> None:
             MenuItem(label=msg("greeter_sub_uninstall"), style="warn"),
             MenuItem(label=msg("greeter_sub_back"), style="subtle"),
         ]
-        menu = Menu("greeter_menu_title", items, hint_key="submenu_hint")
+        menu = Menu("greeter_menu_title", items, hint_key="submenu_hint",
+                    breadcrumb=["NyxNiri", msg("greeter_menu_title").strip()])
         choice = menu.run()
         if choice == 0: greeter_install(); press_any_key()
         elif choice == 1: greeter_status(); press_any_key()
@@ -407,7 +409,8 @@ def fcitx_menu_loop() -> None:
             MenuItem(label=msg("fcitx_sub_uninstall"), style="warn"),
             MenuItem(label=msg("fcitx_sub_back"), style="subtle"),
         ]
-        menu = Menu("fcitx_menu_title", items, hint_key="submenu_hint")
+        menu = Menu("fcitx_menu_title", items, hint_key="submenu_hint",
+                    breadcrumb=["NyxNiri", msg("fcitx_menu_title").strip()])
         choice = menu.run()
         if choice == 0: fcitx_install(); press_any_key()
         elif choice == 1: fcitx_status(); press_any_key()
@@ -426,7 +429,8 @@ def deps_menu_loop() -> None:
             MenuItem(label=msg("deps_sub_apps")),
             MenuItem(label=msg("deps_sub_back"), style="subtle"),
         ]
-        menu = Menu("deps_menu_title", items, hint_key="submenu_hint")
+        menu = Menu("deps_menu_title", items, hint_key="submenu_hint",
+                    breadcrumb=["NyxNiri", msg("deps_menu_title").strip()])
         choice = menu.run()
         if choice == 0: run_dep_menu_loop(); press_any_key()
         elif choice == 1: run_optional_apps_menu_loop(); press_any_key()
@@ -448,7 +452,8 @@ def optional_modules_menu_loop() -> None:
             MenuItem(label=msg("optmod_purge"), style="warn"),
             MenuItem(label=msg("optmod_back"), style="subtle"),
         ]
-        menu = Menu("optmod_menu_title", items, hint_key="submenu_hint")
+        menu = Menu("optmod_menu_title", items, hint_key="submenu_hint",
+                    breadcrumb=["NyxNiri", msg("optmod_menu_title").strip()])
         choice = menu.run()
         if choice == 0: run_optional_apps_menu_loop()
         elif choice == 1: greeter_menu_loop()
@@ -472,7 +477,8 @@ def main_menu_loop() -> None:
             MenuItem(label=msg("menu_opt8")),
             MenuItem(label=msg("menu_opt0"), style="subtle"),
         ]
-        menu = Menu("menu_title", items, hint_key="menu_hint")
+        menu = Menu("menu_title", items, hint_key="menu_hint",
+                    breadcrumb=["NyxNiri"])
         choice = menu.run()
 
         if choice == 0:
@@ -484,8 +490,9 @@ def main_menu_loop() -> None:
         elif choice == 3:
             update_result = safe_git_pull(env.repo_dir)
             if update_result is True:
-                offer_overwrite_upgrade()
-                check_new_deps_post_update()
+                with Spinner(msg("updating_done")):
+                    offer_overwrite_upgrade()
+                    check_new_deps_post_update()
                 print(msg("updating_done"))
                 press_any_key()
                 # Re-exec to load new code

--- a/nyxniri/deploy.py
+++ b/nyxniri/deploy.py
@@ -67,7 +67,7 @@ def discover_config_items() -> List[str]:
     _CONFIG_ITEMS_CACHE = ["fastfetch", "fish", "kitty", "niri", "noctalia", "starship.toml", "xdg-desktop-portal", "zed"]
     return _CONFIG_ITEMS_CACHE
 
-def atomic_replace_item(src: Path, dest: Path, preserved_log: Optional[List[str]] = None, test_mode: bool = False) -> bool:
+def atomic_replace_item(src: Path, dest: Path, preserved_log: Optional[List[str]] = None, test_mode: bool = False, preserved_files: Optional[List[str]] = None) -> bool:
     """Atomic swap deployment via sibling temp directories with Dunder Protocol preservation."""
     pid = os.getpid()
     dest_parent = dest.parent
@@ -149,6 +149,18 @@ def atomic_replace_item(src: Path, dest: Path, preserved_log: Optional[List[str]
                         if preserved_log is not None:
                             preserved_log.append(f"~/.config/{rel_display}/")
 
+        if preserved_files:
+            for rel in preserved_files:
+                src_preserve = dest / rel
+                target_preserve = tmp_new / rel
+                if src_preserve.is_file():
+                    target_preserve.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(src_preserve, target_preserve)
+                    rel_display = str(dest.relative_to(home / ".config") / rel)
+                    print(msg("log_keep_monitor_config", MAIN_WM, MAIN_WM_HARDWARE_CONFIG))
+                    if preserved_log is not None:
+                        preserved_log.append(f"~/.config/{rel_display}")
+
         if dest.exists() or dest.is_symlink():
             old_dest = dest.with_name(f"{dest.name}.old.{pid}")
             dest.rename(old_dest)
@@ -198,26 +210,14 @@ def _phase_atomic_deployment(
         dest = config_dir / item
 
         if src.exists():
-            temp_monitor: Optional[Path] = None
-            if item == MAIN_WM and (dest / MAIN_WM_HARDWARE_CONFIG).is_file():
-                if keep_monitor or os.environ.get("NYXNIRI_KEEP_MONITOR", "0") == "1":
-                    tfd, tname = tempfile.mkstemp()
-                    os.close(tfd)
-                    temp_monitor = Path(tname)
-                    register_temp_path(temp_monitor)
-                    shutil.copy2(dest / MAIN_WM_HARDWARE_CONFIG, temp_monitor)
+            preserved_rel: Optional[List[str]] = None
+            if item == MAIN_WM and keep_monitor and (dest / MAIN_WM_HARDWARE_CONFIG).is_file():
+                preserved_rel = [MAIN_WM_HARDWARE_CONFIG]
 
-            if not atomic_replace_item(src, dest, preserved_log=preserved_log, test_mode=test_mode):
+            if not atomic_replace_item(src, dest, preserved_log=preserved_log, test_mode=test_mode, preserved_files=preserved_rel):
                 failed_items.append(item)
                 print(msg("log_deploy_config_failed", item), file=sys.stderr)
                 continue
-
-            if temp_monitor and temp_monitor.is_file():
-                shutil.copy2(temp_monitor, dest / MAIN_WM_HARDWARE_CONFIG)
-                temp_monitor.unlink(missing_ok=True)
-                print(msg("log_keep_monitor_config", MAIN_WM, MAIN_WM_HARDWARE_CONFIG))
-                if preserved_log is not None:
-                    preserved_log.append(f"~/.config/{MAIN_WM}/{MAIN_WM_HARDWARE_CONFIG}")
 
             print(msg("log_deploy_config_item", item))
             log_msg("INFO", f"Deployed config ~/.config/{item}")

--- a/nyxniri/kdl.py
+++ b/nyxniri/kdl.py
@@ -1,0 +1,346 @@
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Union
+
+
+@dataclass
+class KdlValue:
+    raw: str
+    typ: str = "string"
+
+    @property
+    def value(self) -> Any:
+        if self.typ == "int":
+            return int(self.raw)
+        if self.typ == "float":
+            return float(self.raw)
+        if self.typ == "bool":
+            return self.raw.lower() in ("true", "yes", "on")
+        if self.typ == "null":
+            return None
+        if self.typ == "color":
+            return self.raw
+        return self.raw.strip('"').strip("'")
+
+
+@dataclass
+class KdlNode:
+    name: str = ""
+    values: List[KdlValue] = field(default_factory=list)
+    props: Dict[str, KdlValue] = field(default_factory=dict)
+    children: List["KdlNode"] = field(default_factory=list)
+
+    def child(self, name: str) -> Optional["KdlNode"]:
+        for c in self.children:
+            if c.name == name:
+                return c
+        return None
+
+    def children_by_name(self, name: str) -> List["KdlNode"]:
+        return [c for c in self.children if c.name == name]
+
+    def get(self, key: str, default: Any = None) -> Any:
+        if key in self.props:
+            return self.props[key].value
+        if self.values:
+            return self.values[0].value
+        return default
+
+
+_TOKEN_STRING = re.compile(r'"((?:[^"\\]|\\.)*)"')
+_TOKEN_SSTRING = re.compile(r"'((?:[^'\\]|\\.)*)'")
+_TOKEN_COLOR = re.compile(r'#([0-9a-fA-F]{3,8})\b')
+_TOKEN_NUMBER = re.compile(r'(-?(?:0x[0-9a-fA-F]+|0o[0-7]+|0b[01]+|\d+\.?\d*(?:[eE][+-]?\d+)?))')
+_TOKEN_BOOL = re.compile(r'\b(true|false|yes|no|on|off)\b', re.IGNORECASE)
+_TOKEN_NULL = re.compile(r'\b(null)\b', re.IGNORECASE)
+_TOKEN_IDENT = re.compile(r'([a-zA-Z_][\w\-\.]*)')
+_TOKEN_KEY = re.compile(r'([a-zA-Z_][\w\-\.]*)\s*=')
+
+_NODE_END_CHARS = frozenset('{}()[];')
+_QUOTE_CHARS = frozenset('"\'')
+_ESCAPE_MAP = {
+    'n': '\n',
+    't': '\t',
+    'r': '\r',
+    '\\': '\\',
+    '"': '"',
+    "'": "'",
+    's': ' ',
+    '/': '/',
+}
+
+
+def _unescape(s: str) -> str:
+    result = []
+    i = 0
+    while i < len(s):
+        if s[i] == '\\' and i + 1 < len(s):
+            nxt = s[i + 1]
+            result.append(_ESCAPE_MAP.get(nxt, nxt))
+            i += 2
+        else:
+            result.append(s[i])
+            i += 1
+    return ''.join(result)
+
+
+def _classify_value(raw: str) -> KdlValue:
+    raw = raw.strip()
+    if not raw:
+        return KdlValue(raw="", typ="null")
+    if _TOKEN_BOOL.match(raw):
+        return KdlValue(raw=raw, typ="bool")
+    if _TOKEN_NULL.match(raw):
+        return KdlValue(raw=raw, typ="null")
+    if raw.startswith('#') and _TOKEN_COLOR.match(raw):
+        return KdlValue(raw=raw, typ="color")
+    if raw.startswith('"') or raw.startswith("'"):
+        return KdlValue(raw=raw, typ="string")
+    if _TOKEN_NUMBER.match(raw):
+        if '.' in raw or 'e' in raw or 'E' in raw:
+            return KdlValue(raw=raw, typ="float")
+        return KdlValue(raw=raw, typ="int")
+    return KdlValue(raw=raw, typ="string")
+
+
+class _Tokenizer:
+    def __init__(self, text: str):
+        self.text = text
+        self.pos = 0
+        self.length = len(text)
+
+    def _skip_ws_and_comments(self, stop_at_newline: bool = False) -> None:
+        while self.pos < self.length:
+            ch = self.text[self.pos]
+            if ch == '\n' and stop_at_newline:
+                return
+            if ch in ' \t\r\n':
+                self.pos += 1
+            elif ch == '/' and self.pos + 1 < self.length:
+                nxt = self.text[self.pos + 1]
+                if nxt == '/':
+                    end = self.text.find('\n', self.pos)
+                    self.pos = self.length if end == -1 else end + 1
+                elif nxt == '*':
+                    end = self.text.find('*/', self.pos + 2)
+                    self.pos = self.length if end == -1 else end + 2
+                else:
+                    break
+            else:
+                break
+
+    def _read_string(self, quote: str) -> str:
+        self.pos += 1
+        start = self.pos
+        while self.pos < self.length:
+            ch = self.text[self.pos]
+            if ch == '\\' and self.pos + 1 < self.length:
+                self.pos += 2
+            elif ch == quote:
+                raw = self.text[start:self.pos]
+                self.pos += 1
+                return _unescape(raw)
+            else:
+                self.pos += 1
+        return _unescape(self.text[start:self.pos])
+
+    def _read_bareword(self) -> str:
+        start = self.pos
+        while self.pos < self.length:
+            ch = self.text[self.pos]
+            if ch in ' \t\r\n{}();=\'"':
+                break
+            self.pos += 1
+        return self.text[start:self.pos]
+
+    def parse_node(self, top_level: bool = False) -> Optional[KdlNode]:
+        while True:
+            self._skip_ws_and_comments()
+            if self.pos >= self.length:
+                return None
+
+            ch = self.text[self.pos]
+            if ch == ';':
+                self.pos += 1
+                continue
+            if ch == '}':
+                return None
+            if ch == '\n':
+                self.pos += 1
+                continue
+
+            if ch == '"' or ch == "'":
+                node = KdlNode(name=self._read_string(ch))
+            else:
+                bare = self._read_bareword()
+                if not bare:
+                    self.pos += 1
+                    continue
+                if bare.startswith('#') and len(bare) > 1:
+                    node = KdlNode(name=bare)
+                else:
+                    node = KdlNode(name=bare)
+
+            self._parse_node_body(node)
+            if top_level:
+                pass
+            return node
+
+    def _parse_node_body(self, node: KdlNode) -> None:
+        while True:
+            self._skip_ws_and_comments(stop_at_newline=True)
+            if self.pos >= self.length:
+                break
+            ch = self.text[self.pos]
+            if ch == ';':
+                self.pos += 1
+                break
+            if ch == '{':
+                self.pos += 1
+                while True:
+                    child = self.parse_node()
+                    if child is None:
+                        break
+                    node.children.append(child)
+                if self.pos < self.length and self.text[self.pos] == '}':
+                    self.pos += 1
+                break
+            if ch == '}':
+                break
+            if ch == '\n':
+                self.pos += 1
+                break
+
+            if ch == '"' or ch == "'":
+                val = self._read_string(ch)
+                node.values.append(KdlValue(raw=f'"{val}"', typ="string"))
+                continue
+
+            bare = self._read_bareword()
+            if not bare:
+                self.pos += 1
+                continue
+
+            saved = self.pos
+            self._skip_ws_and_comments()
+            if self.pos < self.length and self.text[self.pos] == '=':
+                self.pos += 1
+                self._skip_ws_and_comments()
+                if self.pos < self.length:
+                    vch = self.text[self.pos]
+                    if vch == '"' or vch == "'":
+                        vraw = f'"{self._read_string(vch)}"'
+                        node.props[bare] = KdlValue(raw=vraw, typ="string")
+                    else:
+                        vbare = self._read_bareword()
+                        node.props[bare] = _classify_value(vbare)
+                continue
+            else:
+                self.pos = saved
+
+            if bare.startswith('#') and len(bare) > 1:
+                node.values.append(KdlValue(raw=bare, typ="color"))
+            else:
+                node.values.append(_classify_value(bare))
+
+
+def parse(text: str) -> KdlNode:
+    root = KdlNode(name="__root__")
+    tok = _Tokenizer(text)
+    while True:
+        node = tok.parse_node(top_level=True)
+        if node is None:
+            break
+        root.children.append(node)
+    return root
+
+
+def parse_file(path: str) -> KdlNode:
+    with open(path, 'r', encoding='utf-8') as f:
+        return parse(f.read())
+
+
+def find_nodes(root: KdlNode, name: str, recursive: bool = False) -> List[KdlNode]:
+    result = []
+    for child in root.children:
+        if child.name == name:
+            result.append(child)
+        if recursive:
+            result.extend(find_nodes(child, name, recursive=True))
+    return result
+
+
+def to_dict(node: KdlNode) -> dict:
+    d: Dict[str, Any] = {}
+    for v in node.values:
+        d.setdefault("_values", []).append(v.value)
+    for k, v in node.props.items():
+        d[k] = v.value
+    for child in node.children:
+        if child.name in d:
+            if not isinstance(d[child.name], list):
+                d[child.name] = [d[child.name]]
+            d[child.name].append(to_dict(child))
+        else:
+            d[child.name] = to_dict(child)
+    return d
+
+
+def get_bind_info(node: KdlNode) -> dict:
+    info = {"name": node.name}
+    for k, v in node.props.items():
+        info[k] = v.value
+    info["args"] = [v.value for v in node.values]
+    info["children"] = [c.name for c in node.children]
+    return info
+
+
+def extract_binds(root: KdlNode) -> List[dict]:
+    binds_block = None
+    for child in root.children:
+        if child.name == "binds":
+            binds_block = child
+            break
+    if binds_block is None:
+        return []
+    result = []
+    for bind in binds_block.children:
+        info = get_bind_info(bind)
+        result.append(info)
+    return result
+
+
+def extract_environment(root: KdlNode) -> Dict[str, str]:
+    env_block = None
+    for child in root.children:
+        if child.name == "environment":
+            env_block = child
+            break
+    if env_block is None:
+        return {}
+    result = {}
+    for child in env_block.children:
+        if child.values:
+            result[child.name] = child.values[0].value
+    return result
+
+
+def extract_spawn_startup(root: KdlNode) -> List[List[str]]:
+    result = []
+    for child in root.children:
+        if child.name == "spawn-at-startup":
+            result.append([v.value for v in child.values])
+    return result
+
+
+def extract_includes(root: KdlNode) -> List[dict]:
+    result = []
+    for child in root.children:
+        if child.name == "include":
+            entry = {"path": "", "optional": False}
+            if child.values:
+                entry["path"] = child.values[0].value
+            if "optional" in child.props:
+                entry["optional"] = child.props["optional"].value
+            result.append(entry)
+    return result

--- a/nyxniri/tui.py
+++ b/nyxniri/tui.py
@@ -1,5 +1,4 @@
 """TUI component and terminal presentation engine (Native ANSI + Standard Library)."""
-
 import atexit
 import os
 import re
@@ -8,20 +7,61 @@ import shutil
 import signal
 import sys
 import termios
+import threading
+import time
 import tty
 import unicodedata
-from dataclasses import dataclass
-from typing import Any, List, Optional
+from dataclasses import dataclass, field
+from typing import Any, Callable, List, Optional
 
 from nyxniri.constants import Colors
 from nyxniri.core import Environment, get_env
 from nyxniri.i18n import msg
 
-ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -/]*[@-~]")
+ANSI_ESCAPE_RE = re.compile(r"\x1b\[[0-?]*[ -\/]*[@-~]")
 
+_terminal_size_cache: Optional[tuple] = None
+
+
+def _get_terminal_size() -> tuple:
+    global _terminal_size_cache
+    if _terminal_size_cache is not None:
+        return _terminal_size_cache
+    size = shutil.get_terminal_size((80, 24))
+    _terminal_size_cache = (size.columns, size.lines)
+    return _terminal_size_cache
+
+
+_winch_handlers: List[Callable] = []
+
+
+def _on_sigwinch(signum, frame) -> None:
+    global _terminal_size_cache
+    _terminal_size_cache = None
+    for h in _winch_handlers:
+        try:
+            h()
+        except Exception:
+            pass
+
+try:
+    signal.signal(signal.SIGWINCH, _on_sigwinch)
+except (AttributeError, ValueError, OSError):
+    pass
+
+
+def _register_winch(handler: Callable) -> None:
+    if handler not in _winch_handlers:
+        _winch_handlers.append(handler)
+
+
+def _unregister_winch(handler: Callable) -> None:
+    try:
+        _winch_handlers.remove(handler)
+    except ValueError:
+        pass
 
 class TerminalGuard:
-    """Fail-safe guard that guarantees terminal attributes and cursor visibility are restored."""
     _orig_attr: Optional[List[Any]] = None
     _initialized: bool = False
 
@@ -55,13 +95,10 @@ class TerminalGuard:
         sys.stdout.write("\n")
         sys.exit(130)
 
-
 TerminalGuard.init()
 
 
-# --- Geometric Column Alignment ---
 def display_width(text: str) -> int:
-    """Calculate the real physical terminal column width of a string (CJK = 2 cols)."""
     clean_text = ANSI_ESCAPE_RE.sub("", text)
     return sum(
         0 if unicodedata.combining(ch) else 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
@@ -70,7 +107,6 @@ def display_width(text: str) -> int:
 
 
 def pad_display(text: str, width: int) -> str:
-    """Pad string with trailing spaces to achieve exact visual column alignment."""
     curr = display_width(text)
     if curr < width:
         return text + (" " * (width - curr))
@@ -78,12 +114,10 @@ def pad_display(text: str, width: int) -> str:
 
 
 def truncate_display(text: str, width: int, suffix: str = "…") -> str:
-    """Clip ANSI-styled text to a physical terminal width without splitting CJK glyphs."""
     if width <= 0:
         return ""
     if display_width(text) <= width:
         return text
-
     suffix_width = display_width(suffix)
     content_width = max(0, width - suffix_width)
     output: List[str] = []
@@ -95,22 +129,22 @@ def truncate_display(text: str, width: int, suffix: str = "…") -> str:
             output.append(match.group(0))
             pos = match.end()
             continue
-        char = text[pos]
-        char_width = 0 if unicodedata.combining(char) else 2 if unicodedata.east_asian_width(char) in ("W", "F") else 1
-        if used + char_width > content_width:
+        ch = text[pos]
+        ch_width = 0 if unicodedata.combining(ch) else 2 if unicodedata.east_asian_width(ch) in ("W", "F") else 1
+        if used + ch_width > content_width:
             break
-        output.append(char)
-        used += char_width
+        output.append(ch)
+        used += ch_width
         pos += 1
     reset = Colors.RESET if ANSI_ESCAPE_RE.search(text) else ""
     return "".join(output) + suffix + reset
 
 
 def responsive_hint(key: str) -> str:
-    """Use compact control hints when the terminal cannot hold the full legend."""
-    if shutil.get_terminal_size((80, 24)).columns >= 72:
+    cols, _ = _get_terminal_size()
+    if cols >= 72:
         return msg(key)
-    short_keys = {
+    short = {
         "menu_hint": "menu_hint_short",
         "submenu_hint": "submenu_hint_short",
         "selective_hint": "checklist_hint_short",
@@ -119,44 +153,37 @@ def responsive_hint(key: str) -> str:
         "opt_apps_menu_hint": "checklist_hint_short",
         "summary_action_hint": "summary_action_hint_short",
     }
-    return msg(short_keys.get(key, key))
+    return msg(short.get(key, key))
 
 
-# --- Single Key Event Listener ---
 def read_key() -> str:
-    """Listen for a single keyboard event using raw unbuffered OS file descriptor reads."""
     if not sys.stdin.isatty():
         return "ENTER"
-
     fd = sys.stdin.fileno()
     old_attr = termios.tcgetattr(fd)
     try:
         tty.setraw(fd)
-        raw_bytes = os.read(fd, 1)
-        if not raw_bytes:
+        raw = os.read(fd, 1)
+        if not raw:
             return "EOF"
-        if raw_bytes == b"\x1b":
+        if raw == b"\x1b":
             ready, _, _ = select.select([fd], [], [], 0.05)
             if ready:
-                raw_bytes += os.read(fd, 31)
-
-        # 1. Standalone ESC
-        if raw_bytes == b"\x1b":
+                raw += os.read(fd, 31)
+        if raw == b"\x1b":
             return "ESC"
-
-        # 2. Arrow keys (CSI: \x1b[ and SS3: \x1bO)
-        if raw_bytes in (b"\x1b[A", b"\x1bOA"):
+        if raw in (b"\x1b[A", b"\x1bOA"):
             return "UP"
-        if raw_bytes in (b"\x1b[B", b"\x1bOB"):
+        if raw in (b"\x1b[B", b"\x1bOB"):
             return "DOWN"
-        if raw_bytes in (b"\x1b[C", b"\x1bOC"):
+        if raw in (b"\x1b[C", b"\x1bOC"):
             return "RIGHT"
-        if raw_bytes in (b"\x1b[D", b"\x1bOD"):
+        if raw in (b"\x1b[D", b"\x1bOD"):
             return "LEFT"
-
-        # 3. CSI Extended keys (Home, End, PageUp, PageDown)
-        if raw_bytes.startswith(b"\x1b["):
-            code = raw_bytes[2:]
+        if raw in (b"\x7f", b"\x08"):
+            return "BACKSPACE"
+        if raw.startswith(b"\x1b["):
+            code = raw[2:]
             if code in (b"H", b"1~"):
                 return "HOME"
             if code in (b"F", b"4~"):
@@ -166,49 +193,43 @@ def read_key() -> str:
             if code == b"6~":
                 return "PAGEDOWN"
             return "ESC"
-
-        # 4. Standard control keys
-        if raw_bytes in (b"\r", b"\n"):
+        if raw in (b"\r", b"\n"):
             return "ENTER"
-        if raw_bytes == b" ":
+        if raw == b" ":
             return "SPACE"
-        if raw_bytes in (b"\x03", b"\x04"):  # Ctrl+C / Ctrl+D — both exit
+        if raw in (b"\x03", b"\x04"):
             return "EXIT"
-
-        # 5. Normal UTF-8 single character
         try:
-            return raw_bytes.decode("utf-8")
+            return raw.decode("utf-8")
         except UnicodeDecodeError:
             return ""
     finally:
         termios.tcsetattr(fd, termios.TCSADRAIN, old_attr)
 
-# --- Rendering Primitives & Screen Cleaners ---
+
 def clear_screen() -> None:
-    """Clear the visible terminal without destroying scrollback history."""
     if sys.stdin.isatty():
         sys.stdout.write("\033[2J\033[H")
         sys.stdout.flush()
 
+
 def write_cleared(text: str) -> None:
-    """Write text, ensuring each line has \\033[K before \\n to wipe right-side ghost chars."""
     if not text:
         return
     lines = text.split("\n")
-    for i, line in enumerate(lines):
+    for i, l in enumerate(lines):
         if i == len(lines) - 1:
-            sys.stdout.write(line)
+            sys.stdout.write(l)
         else:
-            sys.stdout.write(f"{line}\033[K\n")
+            sys.stdout.write(f"{l}\033[K\n")
+
 
 def show_logo(env: Optional[Environment] = None) -> None:
-    """Render the official NyxNiri ASCII brand header."""
     if env is None:
         env = get_env()
-
-    terminal = shutil.get_terminal_size((80, 24))
-    if terminal.columns < 66 or terminal.lines < 20:
-        mode_line = truncate_display(f"Mode: {env.mode_label} ({env.repo_dir})", max(12, terminal.columns - 4))
+    cols, lines = _get_terminal_size()
+    if cols < 66 or lines < 20:
+        mode_line = truncate_display(f"Mode: {env.mode_label} ({env.repo_dir})", max(12, cols - 4))
         logo = (
             f"{Colors.BOLD_PURPLE}\n  NYX NIRI{Colors.RESET}  "
             f"{Colors.BOLD_WHITE}{env.version}{Colors.RESET}\n"
@@ -216,10 +237,9 @@ def show_logo(env: Optional[Environment] = None) -> None:
         )
         write_cleared(logo)
         return
-
     mode_line = truncate_display(
         f"Mode: {env.mode_label} ({env.repo_dir})",
-        max(12, terminal.columns - 4),
+        max(12, cols - 4),
     )
     logo = (
         f"{Colors.BOLD_PURPLE}\n"
@@ -235,8 +255,15 @@ def show_logo(env: Optional[Environment] = None) -> None:
     )
     write_cleared(logo)
 
+
+def render_breadcrumb(trail: Optional[List[str]]) -> None:
+    if not trail:
+        return
+    sep = f" {Colors.DARK_GRAY}›{Colors.RESET} "
+    write_cleared(f"  {sep.join(trail)}\n\n")
+
+
 def render_menu_item(idx: int, label: str, focus: int, style: str = "normal") -> None:
-    """Render a single interactive menu row with line-level erase."""
     if idx == focus:
         prefix = f"  {Colors.BOLD_CYAN}❯ {Colors.RESET}"
         if style == "warn":
@@ -253,43 +280,35 @@ def render_menu_item(idx: int, label: str, focus: int, style: str = "normal") ->
             color = Colors.DARK_GRAY
         else:
             color = ""
-    available = max(1, shutil.get_terminal_size((80, 24)).columns - display_width(prefix) - 1)
-    clipped_label = truncate_display(label, available)
-    sys.stdout.write(f"{prefix}{color}{clipped_label}{Colors.RESET}\033[K\n")
+    cols, _ = _get_terminal_size()
+    avail = max(1, cols - display_width(prefix) - 1)
+    clipped = truncate_display(label, avail)
+    sys.stdout.write(f"{prefix}{color}{clipped}{Colors.RESET}\033[K\n")
 
-def render_check_row(is_focus: bool, check_str: str, label: str) -> None:
-    """Render a single checkbox item row with line-level erase."""
+
+def render_check_row(is_focus: bool, chk: str, label: str) -> None:
     prefix = f"  {Colors.BOLD_CYAN}❯ {Colors.RESET}" if is_focus else "    "
-    available = max(
-        1,
-        shutil.get_terminal_size((80, 24)).columns
-        - display_width(prefix)
-        - display_width(check_str)
-        - 2,
-    )
-    clipped_label = truncate_display(label, available)
+    cols, _ = _get_terminal_size()
+    avail = max(1, cols - display_width(prefix) - display_width(chk) - 2)
+    clipped = truncate_display(label, avail)
     if is_focus:
-        sys.stdout.write(
-            f"  {Colors.BOLD_CYAN}❯ {Colors.RESET}{check_str} "
-            f"{Colors.BOLD_WHITE}{clipped_label}{Colors.RESET}\033[K\n"
-        )
+        sys.stdout.write(f"  {Colors.BOLD_CYAN}❯ {Colors.RESET}{chk} {Colors.BOLD_WHITE}{clipped}{Colors.RESET}\033[K\n")
     else:
-        sys.stdout.write(f"    {check_str} {clipped_label}\033[K\n")
+        sys.stdout.write(f"    {chk} {clipped}\033[K\n")
+
 
 def press_any_key() -> None:
-    """Prompt to press any key to continue."""
     if sys.stdin.isatty():
         sys.stdout.write(msg("press_any_key"))
         sys.stdout.flush()
         read_key()
         sys.stdout.write("\n")
 
-def prompt_confirm(prompt_key: str, default: str = "y") -> bool:
-    """Bilingual prompt confirmation (returns True for Yes, False for No)."""
+
+def prompt_confirm(key: str, default: str = "y") -> bool:
     if os.environ.get("NYXNIRI_AUTO_YES", "0") == "1":
         return True
-
-    sys.stdout.write(msg(prompt_key))
+    sys.stdout.write(msg(key))
     sys.stdout.flush()
     try:
         line = sys.stdin.readline()
@@ -302,7 +321,78 @@ def prompt_confirm(prompt_key: str, default: str = "y") -> bool:
     except Exception:
         return default.lower().startswith("y")
 
-# --- Component: Interactive Menu ---
+class Spinner:
+    FRAMES = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏"
+
+    def __init__(self, label: str):
+        self.label = label
+        self._stop = False
+        self._thread = None
+
+    def __enter__(self):
+        self._stop = False
+        def _spin():
+            i = 0
+            while not self._stop:
+                sys.stdout.write(f"\r{Colors.BOLD_CYAN}{self.FRAMES[i % len(self.FRAMES)]}{Colors.RESET} {self.label}")
+                sys.stdout.flush()
+                i += 1
+                time.sleep(0.08)
+        self._thread = threading.Thread(target=_spin, daemon=True)
+        self._thread.start()
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self._stop = True
+        if self._thread:
+            self._thread.join(timeout=1)
+        sys.stdout.write("\r\033[K")
+        sys.stdout.flush()
+
+
+def read_line(prompt: str, default: str = "") -> str:
+    if not sys.stdin.isatty():
+        return default
+    buf = list(default)
+    cursor = len(default)
+    fd = sys.stdin.fileno()
+    old_attr = termios.tcgetattr(fd)
+    try:
+        tty.setraw(fd)
+        while True:
+            sys.stdout.write(f"\r\033[K{prompt}{''.join(buf)}")
+            sys.stdout.write(f"\r{' ' * cursor}")
+            sys.stdout.flush()
+            key = read_key()
+            if key == "ENTER":
+                sys.stdout.write("\n")
+                return "".join(buf)
+            if key == "ESC":
+                sys.stdout.write("\n")
+                return default
+            if key == "BACKSPACE":
+                if cursor > 0:
+                    buf.pop(cursor - 1)
+                    cursor -= 1
+            elif key == "LEFT":
+                if cursor > 0:
+                    cursor -= 1
+            elif key == "RIGHT":
+                if cursor < len(buf):
+                    cursor += 1
+            elif key == "HOME":
+                cursor = 0
+            elif key == "END":
+                cursor = len(buf)
+            elif key == "EXIT":
+                raise KeyboardInterrupt
+            elif len(key) == 1 and key.isprintable():
+                buf.insert(cursor, key)
+                cursor += 1
+    finally:
+        termios.tcsetattr(fd, termios.TCSADRAIN, old_attr)
+        sys.stdout.flush()
+
 @dataclass
 class MenuItem:
     label: str
@@ -310,59 +400,62 @@ class MenuItem:
     style: str = "normal"
     group_header: Optional[str] = None
 
-
 class Menu:
-    def __init__(self, title_key: str, items: List[MenuItem], hint_key: str = "menu_hint"):
+    def __init__(self, title_key: str, items: List[MenuItem], hint_key: str = "menu_hint",
+                 breadcrumb: Optional[List[str]] = None):
         self.title_key = title_key
         self.items = items
         self.hint_key = hint_key
+        self.breadcrumb = breadcrumb
 
     def run(self, initial_focus: int = 0) -> int:
-        """Run interactive menu loop and return the selected item index."""
         if not sys.stdin.isatty():
             return len(self.items) - 1
-
         clear_screen()
         focus = initial_focus
         max_idx = len(self.items) - 1
         env = get_env()
-
+        redraw = True
+        def _set_redraw():
+            nonlocal redraw
+            redraw = True
+        _register_winch(_set_redraw)
         sys.stdout.write(Colors.CURSOR_HIDE)
         try:
             while True:
-                sys.stdout.write("\033[?25l\033[H")
-                show_logo(env)
-                title = msg(self.title_key).strip("\n")
-                write_cleared(f"{title}\n\n")
-
-                terminal_lines = shutil.get_terminal_size((80, 24)).lines
-                visible_count = max(3, terminal_lines - 18)
-                start = max(0, min(focus - visible_count // 2, len(self.items) - visible_count))
-                end = min(len(self.items), start + visible_count)
-                if start > 0:
-                    write_cleared(f"    {Colors.DARK_GRAY}...{Colors.RESET}\n")
-                for curr_idx in range(start, end):
-                    item = self.items[curr_idx]
-                    if item.group_header:
-                        header = truncate_display(
-                            item.group_header,
-                            max(1, shutil.get_terminal_size((80, 24)).columns - 1),
-                        )
-                        write_cleared(f"{header}\n")
-                    render_menu_item(curr_idx, item.label, focus, item.style)
-                if end < len(self.items):
-                    write_cleared(f"    {Colors.DARK_GRAY}...{Colors.RESET}\n")
-
-                hint = responsive_hint(self.hint_key).strip("\n")
-                write_cleared(f"\n{hint}\n")
-                sys.stdout.write("\033[J")
-                sys.stdout.flush()
-
+                if redraw:
+                    sys.stdout.write("\033[?25l\033[H")
+                    show_logo(env)
+                    if self.breadcrumb:
+                        render_breadcrumb(self.breadcrumb)
+                    title = msg(self.title_key).strip("\n")
+                    write_cleared(f"{title}\n\n")
+                    cols, term_lines = _get_terminal_size()
+                    visible = max(3, term_lines - 18)
+                    start = max(0, min(focus - visible // 2, len(self.items) - visible))
+                    end = min(len(self.items), start + visible)
+                    if start > 0:
+                        write_cleared(f"    {Colors.DARK_GRAY}...{Colors.RESET}\n")
+                    for i in range(start, end):
+                        item = self.items[i]
+                        if item.group_header:
+                            hdr = truncate_display(item.group_header, max(1, cols - 1))
+                            write_cleared(f"{hdr}\n")
+                        render_menu_item(i, item.label, focus, item.style)
+                    if end < len(self.items):
+                        write_cleared(f"    {Colors.DARK_GRAY}...{Colors.RESET}\n")
+                    hint = responsive_hint(self.hint_key).strip("\n")
+                    write_cleared(f"\n{hint}\n")
+                    sys.stdout.write("\033[J")
+                    sys.stdout.flush()
+                    redraw = False
                 key = read_key()
                 if key in ("UP", "k", "K", "LEFT", "h", "H"):
                     focus = max_idx if focus <= 0 else focus - 1
+                    redraw = True
                 elif key in ("DOWN", "j", "J", "RIGHT", "l", "L"):
                     focus = 0 if focus >= max_idx else focus + 1
+                    redraw = True
                 elif key in ("ENTER", "SPACE"):
                     return focus
                 elif key.isdigit() and 1 <= int(key) <= len(self.items):
@@ -372,10 +465,10 @@ class Menu:
                 elif key in ("ESC", "EXIT"):
                     return max_idx
         finally:
+            _unregister_winch(_set_redraw)
             sys.stdout.write(Colors.CURSOR_SHOW)
             sys.stdout.flush()
 
-# --- Component: Checkbox Checklist ---
 @dataclass
 class CheckboxEntry:
     key: str
@@ -383,97 +476,98 @@ class CheckboxEntry:
     checked: bool = False
     is_separator: bool = False
 
-
 class CheckboxList:
-    def __init__(self, title_key: str, entries: List[CheckboxEntry], hint_key: str = "selective_hint"):
+    def __init__(self, title_key: str, entries: List[CheckboxEntry], hint_key: str = "selective_hint",
+                 breadcrumb: Optional[List[str]] = None):
         self.title_key = title_key
         self.entries = entries
         self.hint_key = hint_key
+        self.breadcrumb = breadcrumb
 
     def run(self, accept_defaults: bool = False) -> Optional[List[str]]:
-        """Run checkbox selection loop. Returns list of selected keys, or None if cancelled."""
-        if not any(not entry.is_separator for entry in self.entries):
+        if not any(not e.is_separator for e in self.entries):
             return []
         if not sys.stdin.isatty():
-            if accept_defaults:
-                return [e.key for e in self.entries if not e.is_separator and e.checked]
-            return None
-
+            return [e.key for e in self.entries if not e.is_separator and e.checked] if accept_defaults else None
         clear_screen()
-        selectable = [idx for idx, entry in enumerate(self.entries) if not entry.is_separator]
-        focus_pos = 0
-
+        selectable = [i for i, e in enumerate(self.entries) if not e.is_separator]
+        focus = 0
         env = get_env()
+        redraw = True
+        def _set_redraw():
+            nonlocal redraw
+            redraw = True
+        _register_winch(_set_redraw)
         sys.stdout.write(Colors.CURSOR_HIDE)
         try:
             while True:
-                sys.stdout.write("\033[?25l\033[H")
-                show_logo(env)
-                title = msg(self.title_key).strip("\n")
-                write_cleared(f"{title}\n\n")
-
-                focus = selectable[focus_pos]
-                terminal_lines = shutil.get_terminal_size((80, 24)).lines
-                visible_count = max(4, terminal_lines - 18)
-                start = max(
-                    0,
-                    min(focus - visible_count // 2, len(self.entries) - visible_count),
-                )
-                end = min(len(self.entries), start + visible_count)
-                if start > 0:
-                    write_cleared(f"    {Colors.DARK_GRAY}...{Colors.RESET}\n")
-                for idx in range(start, end):
-                    entry = self.entries[idx]
-                    if entry.is_separator:
-                        write_cleared(f"{entry.label}\n")
-                        continue
-
-                    check_str = (
-                        f"{Colors.BOLD_GREEN}[✓]{Colors.RESET}"
-                        if entry.checked
-                        else f"{Colors.DARK_GRAY}[ ]{Colors.RESET}"
-                    )
-                    render_check_row(idx == focus, check_str, entry.label)
-                if end < len(self.entries):
-                    write_cleared(f"    {Colors.DARK_GRAY}...{Colors.RESET}\n")
-
-                hint = responsive_hint(self.hint_key).strip("\n")
-                write_cleared(f"\n{hint}\n")
-                sys.stdout.write("\033[J")
-                sys.stdout.flush()
-
+                if redraw:
+                    sys.stdout.write("\033[?25l\033[H")
+                    show_logo(env)
+                    if self.breadcrumb:
+                        render_breadcrumb(self.breadcrumb)
+                    title = msg(self.title_key).strip("\n")
+                    write_cleared(f"{title}\n\n")
+                    focus_idx = selectable[focus]
+                    cols, term_lines = _get_terminal_size()
+                    visible = max(4, term_lines - 18)
+                    start = max(0, min(focus_idx - visible // 2, len(self.entries) - visible))
+                    end = min(len(self.entries), start + visible)
+                    if start > 0:
+                        write_cleared(f"    {Colors.DARK_GRAY}...{Colors.RESET}\n")
+                    for i in range(start, end):
+                        e = self.entries[i]
+                        if e.is_separator:
+                            write_cleared(f"{e.label}\n")
+                            continue
+                        chk = f"{Colors.BOLD_GREEN}[✓]{Colors.RESET}" if e.checked else f"{Colors.DARK_GRAY}[ ]{Colors.RESET}"
+                        render_check_row(i == focus_idx, chk, e.label)
+                    if end < len(self.entries):
+                        write_cleared(f"    {Colors.DARK_GRAY}...{Colors.RESET}\n")
+                    hint = responsive_hint(self.hint_key).strip("\n")
+                    write_cleared(f"\n{hint}\n")
+                    sys.stdout.write("\033[J")
+                    sys.stdout.flush()
+                    redraw = False
                 key = read_key()
                 if key in ("UP", "k", "K", "LEFT", "h", "H"):
-                    focus_pos = (focus_pos - 1) % len(selectable)
+                    focus = (focus - 1) % len(selectable)
+                    redraw = True
                 elif key in ("DOWN", "j", "J", "RIGHT", "l", "L"):
-                    focus_pos = (focus_pos + 1) % len(selectable)
+                    focus = (focus + 1) % len(selectable)
+                    redraw = True
                 elif key == "SPACE":
-                    self.entries[focus].checked = not self.entries[focus].checked
+                    idx = selectable[focus]
+                    self.entries[idx].checked = not self.entries[idx].checked
+                    redraw = True
                 elif key in ("a", "A"):
                     for e in self.entries:
                         if not e.is_separator:
                             e.checked = True
+                    redraw = True
                 elif key in ("n", "N"):
                     for e in self.entries:
                         if not e.is_separator:
                             e.checked = False
+                    redraw = True
                 elif key in ("0", "q", "Q", "ESC", "EXIT"):
                     return None
                 elif key.isdigit():
                     num = int(key) - 1
                     if 0 <= num < len(selectable):
-                        focus_pos = num
-                        entry_idx = selectable[focus_pos]
-                        self.entries[entry_idx].checked = not self.entries[entry_idx].checked
+                        focus = num
+                        idx = selectable[focus]
+                        self.entries[idx].checked = not self.entries[idx].checked
+                        redraw = True
                 elif key == "ENTER":
                     return [e.key for e in self.entries if not e.is_separator and e.checked]
         finally:
+            _unregister_winch(_set_redraw)
             sys.stdout.write(Colors.CURSOR_SHOW)
             sys.stdout.flush()
 
-# --- Component: Language Selection ---
+
 def select_language() -> str:
-    """Prompt user to select language mode with smooth arrow keys."""
     if not sys.stdin.isatty():
         from nyxniri.i18n import get_lang
         return get_lang()
@@ -481,32 +575,36 @@ def select_language() -> str:
     clear_screen()
     from nyxniri.i18n import set_lang
     env = get_env()
-    focus = 1  # Default to Simplified Chinese
-
+    focus = 1
+    redraw = True
+    def _set_redraw():
+        nonlocal redraw
+        redraw = True
+    _register_winch(_set_redraw)
     sys.stdout.write(Colors.CURSOR_HIDE)
     try:
         while True:
-            sys.stdout.write("\033[?25l\033[H")
-            show_logo(env)
-            write_cleared(f"  {Colors.BOLD_CYAN}── 请选择语言 / Select Language ──{Colors.RESET}\n\n")
-
-            if focus == 0:
-                sys.stdout.write(f"  {Colors.BOLD_CYAN}❯ {Colors.BOLD_WHITE}English{Colors.RESET}\033[K\n")
-                sys.stdout.write(f"    {Colors.DARK_GRAY}简体中文 (Simplified Chinese){Colors.RESET}\033[K\n")
-            else:
-                sys.stdout.write(f"    {Colors.DARK_GRAY}English{Colors.RESET}\033[K\n")
-                sys.stdout.write(f"  {Colors.BOLD_CYAN}❯ {Colors.BOLD_WHITE}简体中文 (Simplified Chinese){Colors.RESET}\033[K\n")
-
-            hint = "[↑/↓] Move  [Enter] Select"
-            write_cleared(f"\n  {Colors.DARK_GRAY}{hint}{Colors.RESET}\n")
-            sys.stdout.write("\033[J")
-            sys.stdout.flush()
-
+            if redraw:
+                sys.stdout.write("\033[?25l\033[H")
+                show_logo(env)
+                write_cleared(f"  {Colors.BOLD_CYAN}── 请选择语言 / Select Language ──{Colors.RESET}\n\n")
+                if focus == 0:
+                    sys.stdout.write(f"  {Colors.BOLD_CYAN}❯ {Colors.BOLD_WHITE}English{Colors.RESET}\033[K\n")
+                    sys.stdout.write(f"    {Colors.DARK_GRAY}简体中文 (Simplified Chinese){Colors.RESET}\033[K\n")
+                else:
+                    sys.stdout.write(f"    {Colors.DARK_GRAY}English{Colors.RESET}\033[K\n")
+                    sys.stdout.write(f"  {Colors.BOLD_CYAN}❯ {Colors.BOLD_WHITE}简体中文 (Simplified Chinese){Colors.RESET}\033[K\n")
+                write_cleared(f"\n  {Colors.DARK_GRAY}[↑/↓] Move  [Enter] Select\n")
+                sys.stdout.write("\033[J")
+                sys.stdout.flush()
+                redraw = False
             key = read_key()
             if key in ("UP", "k", "K", "LEFT", "h", "H", "1"):
                 focus = 0
+                redraw = True
             elif key in ("DOWN", "j", "J", "RIGHT", "l", "L", "2"):
                 focus = 1
+                redraw = True
             elif key in ("ENTER", "SPACE"):
                 chosen = "en" if focus == 0 else "zh"
                 set_lang(chosen)
@@ -515,5 +613,6 @@ def select_language() -> str:
             elif key in ("ESC", "EXIT"):
                 sys.exit(130)
     finally:
+        _unregister_winch(_set_redraw)
         sys.stdout.write(Colors.CURSOR_SHOW)
         sys.stdout.flush()


### PR DESCRIPTION
TUI 增强 (tui.py)
新增 Spinner 进度指示器，安装/更新各步骤不再黑屏无反馈
新增 read_line() 行内文本编辑器，支持方向键/Home/End/Backspace，替换快照备注的裸 readline
新增面包屑导航，子菜单显示当前路径
新增 SIGWINCH 自动重绘，终端窗口缩放时画面即时刷新
read_key() 增加 BACKSPACE 识别
终端尺寸查询缓存，减少循环内重复系统调用

内置 KDL 解析器 (kdl.py)
纯标准库实现，零依赖
支持注释、字符串转义、属性 key=value、嵌套块、include 指令
提供 parse() / parse_file() / extract_binds() / extract_environment() / extract_spawn_startup() / extract_includes() 等接口
实测正确解析项目的 config.kdl 和 binds.kdl

monitor.kdl 竞态修复 (deploy.py)
原逻辑先整目录替换再事后拷回 monitor.kdl，存在竞态窗口——Niri 的 inotify 会在恢复前检测到目录变化并重载配置，读到被覆盖的仓库默认空 monitor.kdl，导致显示器闪一下
修复方案：将 monitor.kdl 保留逻辑移入 atomic_replace_item 内部，在临时目录阶段就把用户版本放进去，rename 完成后即为最终状态，消除中间态

CLI 接入 (cli.py)
安装流程各步骤用 with Spinner(...) 包装
快照备注输入改用 read_line()
主菜单及各子菜单加面包屑参数