### PR TITLE
fix: 更新 re exec 保护、EyeCare 断链保护、快照自动轮转、diff 查看器降级

### DIFF
--- a/nyxniri/backup.py
+++ b/nyxniri/backup.py
@@ -9,7 +9,7 @@ import tempfile
 from pathlib import Path
 from typing import List, Optional
 
-from nyxniri.constants import CLI_CMD, Colors, PROJECT_NAME
+from nyxniri.constants import CLI_CMD, Colors, MAIN_WM, MAIN_WM_HARDWARE_CONFIG, PROJECT_NAME
 from nyxniri.core import (
     get_env,
     get_pics_dir,
@@ -56,6 +56,25 @@ def get_backup_base_dir() -> Path:
     return get_env().config_dir / PROJECT_NAME / "backups"
 
 
+MAX_SNAPSHOTS = 30
+
+def _prune_old_snapshots(base_dir: Path) -> None:
+    if not base_dir.is_dir():
+        return
+    snapshots = []
+    for d in base_dir.iterdir():
+        if d.is_dir() and not d.is_symlink() and _MANAGED_SNAPSHOT_RE.fullmatch(d.name):
+            snapshots.append(d)
+    if len(snapshots) <= MAX_SNAPSHOTS:
+        return
+    snapshots.sort(key=lambda p: p.name, reverse=True)
+    for old in snapshots[MAX_SNAPSHOTS:]:
+        try:
+            shutil.rmtree(old, ignore_errors=True)
+            log_msg("INFO", f"Pruned old snapshot {old.name}")
+        except Exception:
+            pass
+
 def backup_configs(note: str = "", interactive: bool = True) -> Optional[Path]:
     """Create a complete snapshot of all active dotfiles configurations."""
     from nyxniri.deploy import discover_config_items
@@ -88,6 +107,7 @@ def backup_configs(note: str = "", interactive: bool = True) -> Optional[Path]:
         (tmp_dir / "note.txt").write_text(note.strip(), encoding="utf-8")
 
     tmp_dir.rename(backup_dir)
+    _prune_old_snapshots(base_dir)
     if interactive:
         print(msg("backup_done", str(backup_dir)))
     log_msg("INFO", f"Created configuration snapshot at {backup_dir}")
@@ -213,7 +233,10 @@ def rollback_configs(target_arg: str = "") -> bool:
         snap_item = chosen_backup / item
         dest_item = env.config_dir / item
         if snap_item.exists() or snap_item.is_symlink():
-            if not atomic_replace_item(snap_item, dest_item):
+            preserved_rel = None
+            if item == MAIN_WM and (dest_item / MAIN_WM_HARDWARE_CONFIG).is_file():
+                preserved_rel = [MAIN_WM_HARDWARE_CONFIG]
+            if not atomic_replace_item(snap_item, dest_item, preserved_files=preserved_rel):
                 print(msg("log_deploy_config_failed", item), file=sys.stderr)
                 log_msg("ERROR", f"Failed to restore snapshot item {snap_item}")
                 return False
@@ -279,7 +302,7 @@ def delete_backup(target_arg: str = "") -> bool:
 
     if not deleted:
         return False
-    remaining = len(get_all_backups())
+    remaining = len(backups) - len(deleted)
     if len(deleted) == 1:
         print(msg("delete_done", deleted[0].name, remaining))
     else:

--- a/nyxniri/cli.py
+++ b/nyxniri/cli.py
@@ -1,6 +1,7 @@
 """CLI entry point, command-line arguments dispatcher, and interactive control panel menus."""
 
 import os
+import shutil
 import subprocess
 import sys
 from typing import List, Optional
@@ -329,8 +330,11 @@ def offer_overwrite_upgrade(flag: str = "") -> bool:
             if src.exists() and dest.exists():
                 diff_cmds.append(f"diff -urN --color=always '{dest}' '{src}'")
         if diff_cmds:
-            full_cmd = " ; ".join(diff_cmds) + " | less -R"
-            subprocess.run(full_cmd, shell=True, check=False)
+            full_cmd = " ; ".join(diff_cmds)
+            if shutil.which("less"):
+                subprocess.run(full_cmd + " | less -R", shell=True, check=False)
+            else:
+                subprocess.run(full_cmd, shell=True, check=False)
     else:
         print(msg("log_config_deploy_skipped"))
     return True
@@ -488,8 +492,11 @@ def main_menu_loop() -> None:
                 check_new_deps_post_update()
                 print(msg("updating_done"))
                 press_any_key()
-                # Re-exec to load new code
-                os.execv(sys.executable, [sys.executable, "-m", "nyxniri"])
+                try:
+                    os.execv(sys.executable, [sys.executable, "-m", "nyxniri"])
+                except Exception as e:
+                    log_msg("ERROR", f"Re-exec failed: {e}")
+                    print(msg("updating_failed"), file=sys.stderr)
             elif update_result is False:
                 print(msg("updating_failed"), file=sys.stderr)
             press_any_key()

--- a/nyxniri/deploy.py
+++ b/nyxniri/deploy.py
@@ -67,7 +67,7 @@ def discover_config_items() -> List[str]:
     _CONFIG_ITEMS_CACHE = ["fastfetch", "fish", "kitty", "niri", "noctalia", "starship.toml", "xdg-desktop-portal", "zed"]
     return _CONFIG_ITEMS_CACHE
 
-def atomic_replace_item(src: Path, dest: Path, preserved_log: Optional[List[str]] = None, test_mode: bool = False) -> bool:
+def atomic_replace_item(src: Path, dest: Path, preserved_log: Optional[List[str]] = None, test_mode: bool = False, preserved_files: Optional[List[str]] = None) -> bool:
     """Atomic swap deployment via sibling temp directories with Dunder Protocol preservation."""
     pid = os.getpid()
     dest_parent = dest.parent
@@ -149,6 +149,18 @@ def atomic_replace_item(src: Path, dest: Path, preserved_log: Optional[List[str]
                         if preserved_log is not None:
                             preserved_log.append(f"~/.config/{rel_display}/")
 
+        if preserved_files:
+            for rel in preserved_files:
+                src_p = dest / rel
+                tgt_p = tmp_new / rel
+                if src_p.is_file():
+                    tgt_p.parent.mkdir(parents=True, exist_ok=True)
+                    shutil.copy2(src_p, tgt_p)
+                    rel_display = str(dest.relative_to(home / ".config") / rel)
+                    print(msg("log_keep_monitor_config", MAIN_WM, MAIN_WM_HARDWARE_CONFIG))
+                    if preserved_log is not None:
+                        preserved_log.append(f"~/.config/{rel_display}")
+
         if dest.exists() or dest.is_symlink():
             old_dest = dest.with_name(f"{dest.name}.old.{pid}")
             dest.rename(old_dest)
@@ -198,26 +210,14 @@ def _phase_atomic_deployment(
         dest = config_dir / item
 
         if src.exists():
-            temp_monitor: Optional[Path] = None
-            if item == MAIN_WM and (dest / MAIN_WM_HARDWARE_CONFIG).is_file():
-                if keep_monitor or os.environ.get("NYXNIRI_KEEP_MONITOR", "0") == "1":
-                    tfd, tname = tempfile.mkstemp()
-                    os.close(tfd)
-                    temp_monitor = Path(tname)
-                    register_temp_path(temp_monitor)
-                    shutil.copy2(dest / MAIN_WM_HARDWARE_CONFIG, temp_monitor)
+            preserved_rel: Optional[List[str]] = None
+            if item == MAIN_WM and keep_monitor and (dest / MAIN_WM_HARDWARE_CONFIG).is_file():
+                preserved_rel = [MAIN_WM_HARDWARE_CONFIG]
 
-            if not atomic_replace_item(src, dest, preserved_log=preserved_log, test_mode=test_mode):
+            if not atomic_replace_item(src, dest, preserved_log=preserved_log, test_mode=test_mode, preserved_files=preserved_rel):
                 failed_items.append(item)
                 print(msg("log_deploy_config_failed", item), file=sys.stderr)
                 continue
-
-            if temp_monitor and temp_monitor.is_file():
-                shutil.copy2(temp_monitor, dest / MAIN_WM_HARDWARE_CONFIG)
-                temp_monitor.unlink(missing_ok=True)
-                print(msg("log_keep_monitor_config", MAIN_WM, MAIN_WM_HARDWARE_CONFIG))
-                if preserved_log is not None:
-                    preserved_log.append(f"~/.config/{MAIN_WM}/{MAIN_WM_HARDWARE_CONFIG}")
 
             print(msg("log_deploy_config_item", item))
             log_msg("INFO", f"Deployed config ~/.config/{item}")
@@ -235,7 +235,7 @@ def _phase_atomic_deployment(
     # Initial EyeCare symlink
     effects_normal = config_dir / MAIN_WM / "effects_normal.kdl"
     effects_sym = config_dir / MAIN_WM / "effects.kdl"
-    if effects_normal.is_file() and not effects_sym.exists():
+    if effects_normal.is_file() and not effects_sym.is_symlink():
         try:
             effects_sym.symlink_to(effects_normal)
         except Exception:
@@ -323,15 +323,36 @@ def _phase_post_install_services() -> None:
         from nyxniri.gtktheme import gtktheme_trigger_render
         gtktheme_trigger_render()
         print(msg("log_enable_mpvpaper"))
-        subprocess.run([THEME_ENGINE, "msg", "plugins", "enable", f"{THEME_ENGINE}/mpvpaper"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+        subprocess.run([THEME_ENGINE, "msg", "plugins", "enable", f"{THEME_ENGINE}/mpvpaper"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False, timeout=15)
 
     if shutil.which("fish"):
         print(msg("log_check_fisher"))
         log_msg("INFO", "Checking Fisher plugin manager installation")
-        fish_check = subprocess.run(["fish", "-c", "functions -q fisher; echo $status"], capture_output=True, text=True, check=False)
+        fish_check = subprocess.run(["fish", "-c", "functions -q fisher; echo $status"], capture_output=True, text=True, check=False, timeout=10)
+        fish_plugins = config_dir / "fish" / "fish_plugins"
+        need_update = False
+        if fish_plugins.is_file():
+            state_file = get_env().state_dir / "fish_plugins.hash"
+            current_hash = str(fish_plugins.stat().st_mtime_ns)
+            stored_hash = ""
+            if state_file.is_file():
+                try:
+                    stored_hash = state_file.read_text(encoding="utf-8").strip()
+                except Exception:
+                    pass
+            if current_hash != stored_hash:
+                need_update = True
+                try:
+                    state_file.parent.mkdir(parents=True, exist_ok=True)
+                    state_file.write_text(current_hash, encoding="utf-8")
+                except Exception:
+                    pass
         if fish_check.returncode == 0 and fish_check.stdout.strip() == "0":
-            log_msg("INFO", "Fisher already installed, running update")
-            subprocess.run(["fish", "-c", "fisher update"], check=False)
+            if need_update:
+                log_msg("INFO", "Fisher installed, running update")
+                subprocess.run(["fish", "-c", "fisher update"], check=False, timeout=60)
+            else:
+                log_msg("INFO", "Fisher installed, fish_plugins unchanged")
         else:
             tfd, tname = tempfile.mkstemp(suffix=".fish")
             os.close(tfd)
@@ -404,7 +425,8 @@ def deploy_wallpapers(do_download: bool = False) -> WallpaperDeployResult:
                         success = True
                         break
                     log_msg("WARN", f"Wallpaper mirror [{tag}] returned an incomplete pack")
-                shutil.rmtree(tmp_clone, ignore_errors=True)
+                if tmp_clone.exists():
+                    shutil.rmtree(tmp_clone, ignore_errors=True)
 
             if success:
                 shutil.rmtree(tmp_clone / ".git", ignore_errors=True)

--- a/nyxniri/deps.py
+++ b/nyxniri/deps.py
@@ -15,49 +15,67 @@ from nyxniri.i18n import msg
 from nyxniri.network import git_clone_timeout
 from nyxniri.tui import CheckboxEntry, CheckboxList, pad_display, prompt_confirm
 
-def is_dep_installed(cmd: str) -> bool:
-    """Accurately check whether a specific software or font dependency is installed on the system."""
+_PACMAN_INSTALLED_CACHE: Optional[set] = None
+_FC_LIST_CACHE: Optional[str] = None
+
+def _get_pacman_installed() -> set:
+    global _PACMAN_INSTALLED_CACHE
+    if _PACMAN_INSTALLED_CACHE is not None:
+        return _PACMAN_INSTALLED_CACHE
+    if not shutil.which("pacman"):
+        _PACMAN_INSTALLED_CACHE = set()
+        return _PACMAN_INSTALLED_CACHE
     env = {**os.environ, "LC_ALL": "C"}
+    res = subprocess.run(["pacman", "-Qq"], capture_output=True, text=True, check=False, env=env, timeout=30)
+    if res.returncode == 0:
+        _PACMAN_INSTALLED_CACHE = set(res.stdout.split())
+    else:
+        _PACMAN_INSTALLED_CACHE = set()
+    return _PACMAN_INSTALLED_CACHE
 
-    # 1. Pacman package database (most authoritative on Arch)
-    if shutil.which("pacman"):
-        res = subprocess.run(["pacman", "-Qq", cmd], capture_output=True, text=True, check=False, env=env)
-        if res.returncode == 0:
-            return True
+def _get_fc_list() -> str:
+    global _FC_LIST_CACHE
+    if _FC_LIST_CACHE is not None:
+        return _FC_LIST_CACHE
+    if not shutil.which("fc-list"):
+        _FC_LIST_CACHE = ""
+        return _FC_LIST_CACHE
+    env = {**os.environ, "LC_ALL": "C"}
+    res = subprocess.run(["fc-list", ":", "family"], capture_output=True, text=True, check=False, env=env, timeout=15)
+    _FC_LIST_CACHE = res.stdout.lower() if res.returncode == 0 else ""
+    return _FC_LIST_CACHE
 
-    # 2. Specific runtime / font / tool checks
+def is_dep_installed(cmd: str) -> bool:
+    if cmd in _get_pacman_installed():
+        return True
     if cmd == "inotify-tools":
         return shutil.which("inotifywait") is not None
     elif cmd == "python-gobject":
-        res = subprocess.run([sys.executable, "-c", "import gi"], capture_output=True, check=False)
+        res = subprocess.run([sys.executable, "-c", "import gi"], capture_output=True, check=False, timeout=10)
         return res.returncode == 0
     elif cmd == "gtk-layer-shell":
-        res = subprocess.run([sys.executable, "-c", "import gi; gi.require_version('GtkLayerShell', '0.1')"], capture_output=True, check=False)
+        res = subprocess.run([sys.executable, "-c", "import gi; gi.require_version('GtkLayerShell', '0.1')"], capture_output=True, check=False, timeout=10)
         return res.returncode == 0
     elif cmd == "ttf-jetbrains-mono":
-        if shutil.which("fc-list"):
-            res = subprocess.run(["fc-list", ":", "family"], capture_output=True, text=True, check=False, env=env)
-            return "jetbrains mono" in res.stdout.lower()
+        return "jetbrains mono" in _get_fc_list()
     elif cmd == "ttf-jetbrains-mono-nerd":
-        if shutil.which("fc-list"):
-            res = subprocess.run(["fc-list", ":", "family"], capture_output=True, text=True, check=False, env=env)
-            return bool(re.search(r"jetbrains.*nerd", res.stdout, re.IGNORECASE))
+        return bool(re.search(r"jetbrains.*nerd", _get_fc_list(), re.IGNORECASE))
     elif cmd == "noto-fonts-cjk":
-        if shutil.which("fc-list"):
-            res = subprocess.run(["fc-list", ":", "family"], capture_output=True, text=True, check=False, env=env)
-            return bool(re.search(r"noto.*cjk", res.stdout, re.IGNORECASE))
-
-    # 3. Fallback binary lookup
+        return bool(re.search(r"noto.*cjk", _get_fc_list(), re.IGNORECASE))
     return shutil.which(cmd) is not None
 
+_MISSING_DEPS_CACHE: Optional[List[str]] = None
+
 def check_all_deps() -> Dict[str, bool]:
-    """Check status of all core dependencies."""
     return {dep: is_dep_installed(dep) for dep in CORE_DEPS}
 
 def get_missing_deps() -> List[str]:
-    """Retrieve list of missing core dependencies."""
+    global _MISSING_DEPS_CACHE
+    if _MISSING_DEPS_CACHE is not None:
+        return _MISSING_DEPS_CACHE
     status_map = check_all_deps()
-    return [dep for dep, installed in status_map.items() if not installed]
+    _MISSING_DEPS_CACHE = [dep for dep, installed in status_map.items() if not installed]
+    return _MISSING_DEPS_CACHE
 
 def aur_helper_usable() -> Optional[str]:
     """Return name of a functioning AUR helper (paru or yay) after verifying binary execution."""
@@ -198,7 +216,7 @@ def check_mpvpaper_leak() -> None:
             print(msg("mpvpaper_upgrade_skip"))
 
 def install_selected_deps(selected_deps: List[str]) -> bool:
-    """Install selected packages using pacman or AUR helper."""
+    global _MISSING_DEPS_CACHE, _PACMAN_INSTALLED_CACHE
     if not selected_deps:
         return True
 
@@ -228,6 +246,8 @@ def install_selected_deps(selected_deps: List[str]) -> bool:
     if "mpvpaper" in selected_deps or shutil.which("mpvpaper"):
         check_mpvpaper_leak()
 
+    _MISSING_DEPS_CACHE = None
+    _PACMAN_INSTALLED_CACHE = None
     return True
 
 def run_dep_menu_loop() -> None:

--- a/nyxniri/doctor.py
+++ b/nyxniri/doctor.py
@@ -1,5 +1,6 @@
 """System health diagnostics (System Doctor) and diagnostic report exporter."""
 
+import concurrent.futures
 import datetime
 import os
 import platform
@@ -48,7 +49,7 @@ def _check_noctalia(env) -> None:
         print(msg("doctor_err", _text(f"{THEME_ENGINE}: 未在 PATH 中找到", f"{THEME_ENGINE}: not found in PATH")))
     else:
         try:
-            res = subprocess.run([THEME_ENGINE, "msg", "status"], capture_output=True, check=False)
+            res = subprocess.run([THEME_ENGINE, "msg", "status"], capture_output=True, check=False, timeout=10)
             if res.returncode == 0:
                 print(msg("doctor_ok", _text(f"{THEME_ENGINE}: 守护进程响应正常", f"{THEME_ENGINE}: daemon is responding")))
             else:
@@ -115,7 +116,7 @@ def _check_orbit(env) -> None:
     try:
         res = subprocess.run(
             [sys.executable, "-c", "import gi; gi.require_version('Gtk', '3.0'); gi.require_version('GtkLayerShell', '0.1')"],
-            capture_output=True, check=False,
+            capture_output=True, check=False, timeout=10,
         )
         if res.returncode == 0:
             print(msg("doctor_ok", _text("Orbit: GtkLayerShell Python 运行环境可用", "Orbit: GtkLayerShell Python runtime is available")))
@@ -159,11 +160,11 @@ def _check_brightness(env) -> None:
 def _check_portal_active(env) -> None:
     portal_active = False
     if shutil.which("systemctl"):
-        res = subprocess.run(["systemctl", "--user", "is-active", "xdg-desktop-portal"], capture_output=True, check=False)
+        res = subprocess.run(["systemctl", "--user", "is-active", "xdg-desktop-portal"], capture_output=True, check=False, timeout=10)
         portal_active = res.returncode == 0
     if not portal_active:
         try:
-            res = subprocess.run(["pgrep", "-f", "xdg-desktop-portal"], capture_output=True, check=False)
+            res = subprocess.run(["pgrep", "-f", "xdg-desktop-portal"], capture_output=True, check=False, timeout=10)
             portal_active = res.returncode == 0
         except Exception:
             pass
@@ -174,7 +175,7 @@ def _check_portal_active(env) -> None:
 
 def _check_portal_gtk(env) -> None:
     if shutil.which("pacman"):
-        res = subprocess.run(["pacman", "-Qq", "xdg-desktop-portal-gtk"], capture_output=True, check=False)
+        res = subprocess.run(["pacman", "-Qq", "xdg-desktop-portal-gtk"], capture_output=True, check=False, timeout=10)
         if res.returncode == 0:
             print(msg("doctor_ok", _text("桌面门户: xdg-desktop-portal-gtk 后端已安装", "Desktop Portal: xdg-desktop-portal-gtk backend is installed")))
         else:
@@ -185,6 +186,8 @@ def _check_portal_config(env) -> None:
     portal_conf2 = env.config_dir / "xdg-desktop-portal" / "portals.conf"
     if portal_conf.is_file() or portal_conf2.is_file():
         print(msg("doctor_ok", _text("桌面门户: niri-portals.conf 路由已配置", "Desktop Portal: niri-portals.conf routing is configured")))
+    else:
+        print(msg("doctor_warn", _text("桌面门户: 缺少 niri-portals.conf 路由配置", "Desktop Portal: niri-portals.conf routing is missing")))
 
 _MIN_HOME_FREE_KIB = 10 * 1024 * 1024  # 10 GiB expressed in KiB
 _GIB_KIB = 1024 * 1024
@@ -192,7 +195,7 @@ _MIB_KIB = 1024
 
 def _check_disk_space(env) -> None:
     try:
-        res = subprocess.run(["df", "-k", "--output=avail", str(env.home)], capture_output=True, text=True, check=False)
+        res = subprocess.run(["df", "-k", "--output=avail", str(env.home)], capture_output=True, text=True, check=False, timeout=10)
         lines = res.stdout.strip().splitlines()
         if len(lines) >= 2:
             free_kb = int(lines[1].strip())
@@ -232,7 +235,7 @@ def _check_gtk_theme(env) -> None:
 def _check_vm(env) -> None:
     if shutil.which("lspci"):
         try:
-            res = subprocess.run(["lspci"], capture_output=True, text=True, check=False, env={**os.environ, "LC_ALL": "C"})
+            res = subprocess.run(["lspci"], capture_output=True, text=True, check=False, env={**os.environ, "LC_ALL": "C"}, timeout=10)
             if re.search(r"VMware|VirtualBox|QEMU|Virtio", res.stdout, re.IGNORECASE):
                 print(msg("doctor_warn", _text("检测到虚拟机。请确保 VM 设置中已启用 3D 图形加速", "Virtual Machine detected. Ensure 3D Graphics Acceleration is enabled in VM settings")))
         except Exception:
@@ -280,95 +283,121 @@ def run_doctor() -> bool:
     log_msg("INFO", "System Doctor executed")
     return True
 
+def _run_cmd(cmd, check_which=True, timeout=15):
+    if check_which and not shutil.which(cmd[0]):
+        return None
+    try:
+        return subprocess.run(cmd, capture_output=True, text=True, check=False, env={**os.environ, "LC_ALL": "C"}, timeout=timeout)
+    except Exception:
+        return None
+
 def generate_bug_report() -> Optional[Path]:
-    """Generate a clean, standardized Markdown bug report aggregating system state."""
     print(msg("generating_report"))
     env = get_env()
     env.state_dir.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.datetime.now().strftime("%Y%m%d_%H%M%S")
     report_file = env.state_dir / f"nyxniri-bug-report-{timestamp}.md"
 
-    # OS Info
-    os_name = "Linux"
-    if Path("/etc/os-release").is_file():
-        for line in Path("/etc/os-release").read_text(encoding="utf-8", errors="ignore").splitlines():
-            if line.startswith("PRETTY_NAME="):
-                os_name = line.split("=", 1)[1].strip('"\'')
-                break
+    with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+        futures = {
+            "os": pool.submit(lambda: Path("/etc/os-release").read_text(encoding="utf-8", errors="ignore") if Path("/etc/os-release").is_file() else ""),
+            "lspci": pool.submit(_run_cmd, ["lspci"]),
+            "niri_outputs": pool.submit(_run_cmd, [MAIN_WM, "msg", "outputs"]),
+            "journalctl": pool.submit(_run_cmd, ["journalctl", "--user", "-n", "30", "--no-pager"]),
+            "noctalia_status": pool.submit(_run_cmd, [THEME_ENGINE, "msg", "status"]),
+            "portal_status": pool.submit(_run_cmd, ["systemctl", "--user", "status", "xdg-desktop-portal"]),
+            "df_home": pool.submit(_run_cmd, ["df", "-h", str(env.home)]),
+            "portal_gtk": pool.submit(_run_cmd, ["pacman", "-Qq", "xdg-desktop-portal-gtk"]),
+            "versions": {},
+        }
 
-    # Compositor & Shell
+        version_futures = {}
+        for cmd in (MAIN_WM, THEME_ENGINE, "fish", "starship", "kitty", "mpvpaper", "wpctl", "ddcutil", "brightnessctl"):
+            if cmd == "wpctl":
+                version_futures[cmd] = pool.submit(_run_cmd, ["wireplumber", "--version"], check_which=False)
+            elif cmd == "mpvpaper":
+                version_futures[cmd] = pool.submit(_run_cmd, ["pacman", "-Q", "mpvpaper", "mpvpaper-git"], check_which=False)
+            else:
+                version_futures[cmd] = pool.submit(_run_cmd, [cmd, "--version"], check_which=False)
+
+        results = {}
+        for key, fut in futures.items():
+            if key == "versions":
+                continue
+            results[key] = fut.result()
+
+        version_results = {}
+        for cmd, fut in version_futures.items():
+            version_results[cmd] = fut.result()
+
+    os_name = "Linux"
+    for line in results.get("os", "").splitlines():
+        if line.startswith("PRETTY_NAME="):
+            os_name = line.split("=", 1)[1].strip('"\'')
+            break
+
     compositor = os.environ.get("XDG_CURRENT_DESKTOP", "Unknown")
     session_type = os.environ.get("XDG_SESSION_TYPE", "Unknown")
     shell = os.environ.get("SHELL", "Unknown")
 
-    # GPU
     gpu_info = "Unknown"
-    try:
-        res = subprocess.run(["lspci"], capture_output=True, text=True, check=False, env={**os.environ, "LC_ALL": "C"})
-        gpu_lines = [line for line in res.stdout.splitlines() if "VGA" in line or "3D" in line or "Display" in line]
+    lspci_res = results.get("lspci")
+    if lspci_res:
+        gpu_lines = [line for line in lspci_res.stdout.splitlines() if "VGA" in line or "3D" in line or "Display" in line]
         if gpu_lines:
             gpu_info = "\n".join(gpu_lines)
-    except Exception:
-        pass
 
-    # Connected Displays
     displays = "Unknown"
-    if shutil.which(MAIN_WM):
-        res = subprocess.run([MAIN_WM, "msg", "outputs"], capture_output=True, text=True, check=False)
-        displays = res.stdout.strip() if res.returncode == 0 and res.stdout.strip() else f"{MAIN_WM} msg outputs failed"
+    niri_res = results.get("niri_outputs")
+    if niri_res:
+        displays = niri_res.stdout.strip() if niri_res.returncode == 0 and niri_res.stdout.strip() else f"{MAIN_WM} msg outputs failed"
 
-    # Tool Versions
     tool_lines = []
     for cmd in (MAIN_WM, THEME_ENGINE, "fish", "starship", "kitty", "mpvpaper", "wpctl", "ddcutil", "brightnessctl"):
-        if shutil.which(cmd):
-            ver = ""
-            if cmd == "wpctl":
-                res = subprocess.run(["wireplumber", "--version"], capture_output=True, text=True, check=False)
-                ver = next((l for l in res.stdout.splitlines() if "libwireplumber" in l.lower()), "")
-                if not ver:
-                    res = subprocess.run(["pacman", "-Q", "wireplumber"], capture_output=True, text=True, check=False)
-                    ver = res.stdout.strip() or "installed"
-            elif cmd == "mpvpaper":
-                res = subprocess.run(["pacman", "-Q", "mpvpaper", "mpvpaper-git"], capture_output=True, text=True, check=False)
-                ver = res.stdout.splitlines()[0] if res.stdout.strip() else "installed"
-            else:
-                res = subprocess.run([cmd, "--version"], capture_output=True, text=True, check=False)
-                ver = res.stdout.splitlines()[0] if res.stdout.strip() else (res.stderr.splitlines()[0] if res.stderr.strip() else "installed")
-            tool_lines.append(f"{cmd}: {ver}")
-        else:
+        if not shutil.which(cmd):
             tool_lines.append(f"{cmd}: NOT INSTALLED")
+            continue
+        res = version_results.get(cmd)
+        if not res:
+            tool_lines.append(f"{cmd}: NOT INSTALLED")
+            continue
+        if cmd == "wpctl":
+            ver = next((l for l in res.stdout.splitlines() if "libwireplumber" in l.lower()), "")
+            if not ver:
+                pacman_res = _run_cmd(["pacman", "-Q", "wireplumber"])
+                ver = pacman_res.stdout.strip() if pacman_res else "installed"
+        elif cmd == "mpvpaper":
+            ver = res.stdout.splitlines()[0] if res.stdout.strip() else "installed"
+        else:
+            ver = res.stdout.splitlines()[0] if res.stdout.strip() else (res.stderr.splitlines()[0] if res.stderr.strip() else "installed")
+        tool_lines.append(f"{cmd}: {ver}")
     tool_versions = "\n".join(tool_lines)
 
-    # Daemon & Service Status
     daemon_lines = []
-    if shutil.which(THEME_ENGINE):
-        res = subprocess.run([THEME_ENGINE, "msg", "status"], capture_output=True, text=True, check=False)
+    noct_res = results.get("noctalia_status")
+    if noct_res:
         daemon_lines.append(f"--- {THEME_ENGINE} status ---")
-        daemon_lines.append(res.stdout.strip() if res.returncode == 0 else f"{THEME_ENGINE} daemon not responding")
-    if shutil.which("systemctl"):
-        res = subprocess.run(["systemctl", "--user", "status", "xdg-desktop-portal"], capture_output=True, text=True, check=False)
+        daemon_lines.append(noct_res.stdout.strip() if noct_res.returncode == 0 else f"{THEME_ENGINE} daemon not responding")
+    portal_res = results.get("portal_status")
+    if portal_res:
         daemon_lines.append("\n--- Desktop portal status ---")
-        daemon_lines.append("\n".join(res.stdout.splitlines()[:10]) if res.stdout.strip() else "xdg-desktop-portal service check failed")
+        daemon_lines.append("\n".join(portal_res.stdout.splitlines()[:10]) if portal_res.stdout.strip() else "xdg-desktop-portal service check failed")
     daemon_status = "\n".join(daemon_lines)
 
-    # Health Checks
     health_lines = []
-    if shutil.which("pacman"):
-        res = subprocess.run(["pacman", "-Qq", "xdg-desktop-portal-gtk"], capture_output=True, text=True, check=False)
-        health_lines.append(f"xdg-desktop-portal-gtk: {'installed' if res.returncode == 0 else 'NOT INSTALLED'}")
-    try:
-        res = subprocess.run(["df", "-h", str(env.home)], capture_output=True, text=True, check=False)
-        lines = res.stdout.strip().splitlines()
+    portal_gtk_res = results.get("portal_gtk")
+    if portal_gtk_res:
+        health_lines.append(f"xdg-desktop-portal-gtk: {'installed' if portal_gtk_res.returncode == 0 else 'NOT INSTALLED'}")
+    df_res = results.get("df_home")
+    if df_res:
+        lines = df_res.stdout.strip().splitlines()
         if len(lines) >= 2:
             health_lines.append(f"home free space: {lines[1].split()[3]}")
-    except Exception:
-        pass
     if shutil.which("fcitx5") or (env.config_dir / "fcitx5" / "conf" / "classicui.conf").is_file():
         from nyxniri.fcitx import fcitx_enabled
         health_lines.append(f"fcitx5 nyxmellow: {'enabled' if fcitx_enabled() else 'NOT enabled'}")
     health_checks = "\n".join(health_lines)
 
-    # Noctalia Hook Log
     hook_log_path = Path(os.environ.get("XDG_STATE_HOME", str(env.home / ".local" / "state"))) / THEME_ENGINE / "hook.log"
     if hook_log_path.is_file():
         try:
@@ -378,14 +407,11 @@ def generate_bug_report() -> Optional[Path]:
     else:
         hook_log = f"No hook.log found at {hook_log_path}"
 
-    # Systemd Journal
-    if shutil.which("journalctl"):
-        res = subprocess.run(["journalctl", "--user", "-n", "30", "--no-pager"], capture_output=True, text=True, check=False)
-        journal = res.stdout.strip() if res.stdout.strip() else "journalctl log access unavailable"
-    else:
-        journal = "journalctl not available"
+    journal_res = results.get("journalctl")
+    journal = "journalctl not available"
+    if journal_res:
+        journal = journal_res.stdout.strip() if journal_res.stdout.strip() else "journalctl log access unavailable"
 
-    # Recent install log (last 30 lines)
     recent_log = "No log found."
     log_path = env.state_dir / "install.log"
     if log_path.is_file():

--- a/nyxniri/fcitx.py
+++ b/nyxniri/fcitx.py
@@ -130,20 +130,18 @@ def fcitx_configure_quickphrase() -> None:
     _update_ini_file(qp_conf, "Hotkey", "AlternativeTriggerKey", "")
 
 def fcitx_restart() -> None:
-    """Restart running fcitx5 daemon to load updated skin."""
     if fcitx5_installed():
-        res = subprocess.run(["pgrep", "-x", "fcitx5"], capture_output=True, check=False)
+        res = subprocess.run(["pgrep", "-x", "fcitx5"], capture_output=True, check=False, timeout=5)
         if res.returncode == 0:
-            subprocess.run(["pkill", "-x", "fcitx5"], check=False)
+            subprocess.run(["pkill", "-x", "fcitx5"], check=False, timeout=5)
             time.sleep(1)
             subprocess.Popen(["fcitx5", "-d"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
             print(msg("fcitx_restarted"))
 
 def fcitx_trigger_render() -> None:
-    """Ask Noctalia daemon to render templates for current palette."""
     if noctalia_available():
-        subprocess.run([THEME_ENGINE, "msg", "config-reload"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
-        res = subprocess.run([THEME_ENGINE, "msg", "templates-apply"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+        subprocess.run([THEME_ENGINE, "msg", "config-reload"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False, timeout=15)
+        res = subprocess.run([THEME_ENGINE, "msg", "templates-apply"], stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False, timeout=30)
         if res.returncode == 0:
             print(msg("fcitx_render_ok"))
         else:

--- a/nyxniri/gtktheme.py
+++ b/nyxniri/gtktheme.py
@@ -63,11 +63,11 @@ def gtktheme_trigger_render() -> None:
 
     subprocess.run(
         [THEME_ENGINE, "msg", "config-reload"],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False, timeout=15,
     )
     res = subprocess.run(
         [THEME_ENGINE, "msg", "templates-apply"],
-        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False, timeout=30,
     )
     if res.returncode == 0:
         print(msg("gtk_render_ok"))

--- a/nyxniri/network.py
+++ b/nyxniri/network.py
@@ -44,7 +44,7 @@ def _run_cancellable_process(
             **kwargs,
         )
         try:
-            stdout, _ = process.communicate(timeout=120)
+            stdout, _ = process.communicate(timeout=60)
         except subprocess.TimeoutExpired:
             process.kill()
             process.wait(timeout=5)
@@ -284,6 +284,7 @@ def safe_git_pull(target_dir: Path) -> Optional[bool]:
         text=True,
         check=False,
         env=env,
+        timeout=15,
     )
     if res_status.stdout.strip():
         # Dirty tree
@@ -299,8 +300,8 @@ def safe_git_pull(target_dir: Path) -> Optional[bool]:
         if not prompt_confirm("dirty_tree_confirm", "n"):
             print(msg("update_cancelled_dirty"))
             return None
-        subprocess.run(["git", "reset", "--hard", "HEAD"], cwd=target_dir, check=False, env=env)
-        subprocess.run(["git", "clean", "-fd"], cwd=target_dir, check=False, env=env)
+        subprocess.run(["git", "reset", "--hard", "HEAD"], cwd=target_dir, check=False, env=env, timeout=15)
+        subprocess.run(["git", "clean", "-fd"], cwd=target_dir, check=False, env=env, timeout=15)
 
     # Fetch & pull
     sys.stdout.write(msg("checking_updates") + "\n")
@@ -331,6 +332,7 @@ def safe_git_pull(target_dir: Path) -> Optional[bool]:
             text=True,
             check=False,
             env=env,
+            timeout=15,
         )
         return res_reset.returncode == 0
     log_msg("ERROR", f"Failed to update repository: {target_dir}")

--- a/nyxniri/network.py
+++ b/nyxniri/network.py
@@ -115,8 +115,8 @@ def _with_git_progress(command: List[str]) -> Tuple[List[str], bool]:
 
 
 def _run_git_transfer(command: List[str], **kwargs: Any) -> subprocess.CompletedProcess[str]:
-    """Run a Git network command with native TTY progress and quiet automation output."""
     progress_command, show_progress = _with_git_progress(command)
+    kwargs.setdefault("timeout", 120)
     return subprocess.run(
         progress_command,
         capture_output=not show_progress,


### PR DESCRIPTION
更新流程的 os.execv 如果失败会直接闪退，现在包了 try except，失败时记录日志并提示用户

diff 查看器依赖 less 管道，less 不存在时改为直接输出到终端

EyeCare 符号链接判断从 exists 改为 is_symlink，断链时不会覆盖用户当前护眼状态

快照新增自动轮转，上限 30 个，超出自动清理最旧的。delete_backup 删除后不再重复全量扫描目录算剩余数量

atomic_replace_item 新增 preserved_files 参数，monitor.kdl 在原子替换内部完成保留，消除竞态窗口。回滚时同样保留 monitor.kdl，与部署机制对称

Fisher 更新改为按 fish_plugins 文件 mtime 变化触发，没变就不跑网络请求

git pull 和 fetch 加 120 秒兜底超时。壁纸下载多镜像失败后清理临时目录，避免下一轮 clone 到非空目录报错