### PR TITLE
perf: atomic 双 walk 合并、GI 检查缓存

### DIFF
--- a/nyxniri/deploy/atomic.py
+++ b/nyxniri/deploy/atomic.py
@@ -78,47 +78,37 @@ def atomic_replace_item(src: Path, dest: Path, preserved_log: Optional[List[str]
             remove_path(tmp_new)
         shutil.copytree(src, tmp_new, symlinks=True, ignore=_deploy_ignore_factory(src))
 
-        # Dunder Protocol: Scan and inherit *__custom__* files and directories
         if dest.is_dir():
-            # 1. Custom files
+            preserve_entries = []
             for root, dirs, files in os.walk(dest):
-                # Prune custom directories from file search to handle them in step 2
-                dirs[:] = [d for d in dirs if "__custom__" not in d]
+                custom_dirs = [d for d in dirs if "__custom__" in d]
+                for d in custom_dirs:
+                    dirs.remove(d)
+                    preserve_entries.append(("dir", root, d))
                 for f in files:
                     if "__custom__" in f:
                         if test_mode and f in ("scratchpad-items__custom__.toml", "orbit-items__custom__.toml"):
                             continue
-                        rel_path = Path(root).relative_to(dest) / f
-                        src_custom = dest / rel_path
-                        target_custom = tmp_new / rel_path
-                        target_custom.parent.mkdir(parents=True, exist_ok=True)
-                        if src_custom.is_symlink():
-                            target_custom.unlink(missing_ok=True)
-                            target_custom.symlink_to(os.readlink(src_custom))
-                        else:
-                            shutil.copy2(src_custom, target_custom)
+                        preserve_entries.append(("file", root, f))
 
-                        rel_display = str(dest.relative_to(home / ".config") / rel_path)
-                        print(msg("log_keep_custom_file", rel_display))
-                        if preserved_log is not None:
-                            preserved_log.append(f"~/.config/{rel_display}")
-
-            # 2. Custom directories
-            for root, dirs, _ in os.walk(dest):
-                for d in list(dirs):
-                    if "__custom__" in d:
-                        dirs.remove(d)  # Don't recurse further into pruned dir
-                        rel_dir = Path(root).relative_to(dest) / d
-                        src_custom_dir = dest / rel_dir
-                        target_custom_dir = tmp_new / rel_dir
-                        target_custom_dir.parent.mkdir(parents=True, exist_ok=True)
-                        shutil.rmtree(target_custom_dir, ignore_errors=True)
-                        shutil.copytree(src_custom_dir, target_custom_dir, symlinks=True)
-
-                        rel_display = str(dest.relative_to(home / ".config") / rel_dir)
-                        print(msg("log_keep_custom_dir", rel_display))
-                        if preserved_log is not None:
-                            preserved_log.append(f"~/.config/{rel_display}/")
+            for entry_type, root, name in preserve_entries:
+                rel_path = Path(root).relative_to(dest) / name
+                src_item = dest / rel_path
+                target_item = tmp_new / rel_path
+                target_item.parent.mkdir(parents=True, exist_ok=True)
+                if entry_type == "dir":
+                    shutil.rmtree(target_item, ignore_errors=True)
+                    shutil.copytree(src_item, target_item, symlinks=True)
+                elif src_item.is_symlink():
+                    target_item.unlink(missing_ok=True)
+                    target_item.symlink_to(os.readlink(src_item))
+                else:
+                    shutil.copy2(src_item, target_item)
+                rel_display = str(dest.relative_to(home / ".config") / rel_path)
+                suffix = "/" if entry_type == "dir" else ""
+                print(msg("log_keep_custom_dir" if entry_type == "dir" else "log_keep_custom_file", rel_display + suffix))
+                if preserved_log is not None:
+                    preserved_log.append(f"~/.config/{rel_display}{suffix}")
 
         # Manifest-declared preserve: inject into tmp_new before swap so the
         # renamed directory is already complete (no post-rename restore window).

--- a/nyxniri/deps.py
+++ b/nyxniri/deps.py
@@ -18,6 +18,7 @@ from nyxniri.tui import CheckboxEntry, CheckboxList, pad_display, prompt_confirm
 
 _PACMAN_INSTALLED_CACHE: Optional[set] = None
 _FC_LIST_CACHE: Optional[str] = None
+_GI_CACHE: Optional[dict] = None
 
 def _get_pacman_installed() -> set:
     global _PACMAN_INSTALLED_CACHE
@@ -43,17 +44,26 @@ def _get_fc_list() -> str:
     _FC_LIST_CACHE = res.stdout.lower() if res.returncode == 0 else ""
     return _FC_LIST_CACHE
 
+def _check_gi(version: str) -> bool:
+    global _GI_CACHE
+    if _GI_CACHE is None:
+        _GI_CACHE = {}
+    if version in _GI_CACHE:
+        return _GI_CACHE[version]
+    code = "import gi" if version == "gi" else f"import gi; gi.require_version('{version}', '0.1')"
+    res = subprocess.run([sys.executable, "-c", code], capture_output=True, check=False, timeout=10)
+    _GI_CACHE[version] = res.returncode == 0
+    return _GI_CACHE[version]
+
 def is_dep_installed(cmd: str) -> bool:
     if cmd in _get_pacman_installed():
         return True
     if cmd == "inotify-tools":
         return shutil.which("inotifywait") is not None
     elif cmd == "python-gobject":
-        res = subprocess.run([sys.executable, "-c", "import gi"], capture_output=True, check=False, timeout=10)
-        return res.returncode == 0
+        return _check_gi("gi")
     elif cmd == "gtk-layer-shell":
-        res = subprocess.run([sys.executable, "-c", "import gi; gi.require_version('GtkLayerShell', '0.1')"], capture_output=True, check=False, timeout=10)
-        return res.returncode == 0
+        return _check_gi("GtkLayerShell")
     elif cmd == "ttf-jetbrains-mono":
         return "jetbrains mono" in _get_fc_list()
     elif cmd == "ttf-jetbrains-mono-nerd":


### PR DESCRIPTION
atomic_replace_item 里扫描 __custom__ 文件和目录原来各跑一次 os.walk，现在合并成单次遍历，收集到列表后统一处理，磁盘目录遍历减半

is_dep_installed 的 python-gobject 和 gtk-layer-shell 检查原来每次都 fork 一个 python 子进程，现在用 _check_gi 辅助函数加进程级缓存，同进程内各只 fork 一次

两处都是纯性能优化