### PR TITLE
fix: greeter 卸载时禁用 greetd 并恢复原显示管理器

### DIFF
--- a/nyxniri/modules/greeter.py
+++ b/nyxniri/modules/greeter.py
@@ -191,9 +191,12 @@ def greeter_status() -> None:
             print(msg("doctor_warn", text("greetd 服务: 未启用", "greetd service: disabled")))
 
 def greeter_uninstall() -> bool:
-    """Uninstall Noctalia Greeter configuration and restore backups."""
     print(msg("greeter_uninstall_title"))
-
+    if shutil.which("systemctl"):
+        res = subprocess.run(["systemctl", "is-enabled", "greetd"], capture_output=True, check=False, timeout=10)
+        if res is not None and res.returncode == 0:
+            subprocess.run(["sudo", "systemctl", "disable", "greetd"], check=False, timeout=15)
+            print(msg("greeter_disabled"))
     bak = Path(f"{GREETER_ETC_CFG}.nyxniri.bak")
     if bak.is_file():
         restore_cmd = f"mv {bak} {GREETER_ETC_CFG}"
@@ -201,15 +204,18 @@ def greeter_uninstall() -> bool:
         print(msg("greeter_uninstall_restored", str(GREETER_ETC_CFG)))
     else:
         print(msg("greeter_uninstall_nobackup"))
-
     if GREETER_POLKIT_RULE.is_file():
         subprocess.run(["sudo", "rm", "-f", str(GREETER_POLKIT_RULE)], check=False)
         print(msg("greeter_uninstall_polkit"))
-
-    # Remove the greeter's state directory (created at install; previously leaked)
     subprocess.run(["sudo", "rm", "-rf", str(GREETER_STATE_DIR)], check=False)
     print(msg("greeter_uninstall_state_dir", str(GREETER_STATE_DIR)))
-
+    if shutil.which("systemctl"):
+        for dm in CONFLICT_DMS:
+            res = subprocess.run(["systemctl", "is-enabled", dm], capture_output=True, check=False, timeout=10)
+            if res is not None and res.returncode == 0:
+                subprocess.run(["sudo", "systemctl", "enable", "--force", dm], check=False, timeout=15)
+                print(msg("greeter_dm_restored", dm))
+                break
     print(msg("greeter_uninstall_done"))
     log_msg("INFO", "Uninstalled Noctalia Greeter configuration")
     return True


### PR DESCRIPTION
greeter_uninstall 原来只删配置和 polkit 规则，不禁用 greetd 服务也不恢复之前被禁用的显示管理器，卸载后重启会进不了图形界面

现在卸载时先禁用 greetd，清理完配置后扫描已安装的冲突显示管理器并用 enable force 恢复，和 install 流程对称