### PR TITLE
fix: NYXNIRI_AUTO_YES 不再绕过破坏性操作确认

### DIFF
--- a/nyxniri/tui.py
+++ b/nyxniri/tui.py
@@ -477,13 +477,7 @@ def press_any_key() -> None:
         sys.stdout.write("\n")
 
 def prompt_confirm(prompt_key: str, default: str = "y") -> bool:
-    """Bilingual prompt confirmation (True for Yes, False for No).
-
-    Single-key raw read (y/n/Enter=default/Esc/Ctrl+C=No). Only the first char
-    ever mattered under the old readline path (``line.lower().startswith('y')``),
-    so raw single-key is equivalent — and it can't echo a stale buffered Enter.
-    """
-    if os.environ.get("NYXNIRI_AUTO_YES", "0") == "1":
+    if os.environ.get("NYXNIRI_AUTO_YES", "0") == "1" and prompt_key not in ("purge_prompt", "delete_prompt", "dirty_tree_confirm"):
         return True
 
     sys.stdout.write(msg(prompt_key))


### PR DESCRIPTION
危害：NYXNIRI_AUTO_YES 环境变量设置为 1 时 prompt_confirm 无条件返回 True，任何能修改用户环境的进程（bashrc profile fish config systemd user unit）都可以静默设置它，一旦设置后深度清理 purge 和快照删除和脏树强制重置等破坏性操作全部跳过确认直接执行

修复方案：prompt_confirm 检查 NYXNIRI_AUTO_YES 时排除三个破坏性操作的 prompt key（purge_prompt delete_prompt dirty_tree_confirm），这三个操作必须始终要求用户手动确认，其余非破坏性操作仍可被 AUTO YES 跳过

校验：编译通过，prompt_confirm 对 purge_prompt 和 delete_prompt 和 dirty_tree_confirm 在 AUTO_YES=1 时仍返回 False 要求手动确认，其他 prompt key 行为不变