### PR TITLE
fix: orbit launcher 命令注入校验

### DIFF
--- a/configs/niri/scripts/orbit/window.py
+++ b/configs/niri/scripts/orbit/window.py
@@ -346,7 +346,6 @@ class OrbitLauncher(Gtk.Window):
         url = item.get("url", "")
         cmd = item.get("cmd") or item.get("id") or item.get("name", "").lower()
         target_url = url if url else (cmd if cmd.startswith(("http://", "https://", "www.")) else "")
-
         if target_url:
             if target_url.startswith("www."):
                 target_url = "https://" + target_url
@@ -356,11 +355,14 @@ class OrbitLauncher(Gtk.Window):
                 print(f"Error opening URL: {e}", file=sys.stderr)
             self.dismiss_menu()
             return
-
-        # 3. Local Scratchpad / App Command
+        import shlex
         script_path = os.path.expanduser("~/.config/niri/scripts/niri-scratch-toggle.sh")
         if not os.path.isfile(script_path):
             script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "niri-scratch-toggle.sh")
+        if not cmd or any(c in cmd for c in (";", "|", "&", "`", "$", "(", ")", "{", "}", "<", ">", "\n", "\r")):
+            print(f"Rejected unsafe command: {cmd}", file=sys.stderr)
+            self.dismiss_menu()
+            return
         try:
             subprocess.Popen(["/bin/bash", script_path, cmd])
         except Exception as e:


### PR DESCRIPTION
危害：orbit launcher 从 orbit-items__custom__.toml 加载菜单项，cmd 字段被直接传给 niri-scratch-toggle.sh，脚本的 fallback 分支执行 bash -c 将 cmd 内容作为 shell 命令执行，攻击者在 TOML 配置中注入恶意 cmd 值可实现任意代码执行

修复方案：在将 cmd 传给脚本前校验内容，拒绝包含分号管道符反引号美元符号括号花括号尖括号换行符等 shell 元字符的命令，校验失败时拒绝执行并打印警告

校验：编译通过，包含 shell 元字符的 cmd 被拒绝执行，正常的 kitty 和 missioncenter 和 wallpaper-picker 等命令不受影响