### PR TITLE
fix: NYXNIRI_REPO 环境变量协议校验

### DIFF
--- a/nyxniri/constants.py
+++ b/nyxniri/constants.py
@@ -21,9 +21,9 @@ ASSETS_DIR_NAME = "assets"
 
 # --- Repository & Network Mirrors ---
 REPO_URL = "https://github.com/ech678/NyxNiri.git"
-
-if os.environ.get("NYXNIRI_REPO"):
-    GIT_MIRROR_REGISTRY = [("Custom", os.environ["NYXNIRI_REPO"])]
+_custom_repo = os.environ.get("NYXNIRI_REPO", "")
+if _custom_repo and (_custom_repo.startswith("https://") or _custom_repo.startswith("git@") or _custom_repo.startswith("ssh://")) and "://" in _custom_repo:
+    GIT_MIRROR_REGISTRY = [("Custom", _custom_repo)]
 else:
     GIT_MIRROR_REGISTRY = [
         ("Official", "https://github.com/ech678/NyxNiri.git"),


### PR DESCRIPTION
危害：NYXNIRI_REPO 环境变量设置后所有镜像回退机制被完全绕过直接从用户指定 URL 克隆代码，克隆下来的代码被 exec python3 -m nyxniri 直接执行没有任何 commit 签名验证 tag 校验或哈希比对，如果攻击者能控制环境变量（通过 bashrc fish config systemd user unit 桌面环境 autostart）就能让用户在不知情的情况下运行攻击者控制的代码仓库

修复方案：NYXNIRI_REPO 只接受以 https:// 或 git@ 或 ssh:// 开头的 URL，拒绝 file:// 协议和本地路径以及其他非 git 协议，不满足协议要求时回退到默认官方镜像

校验：编译通过，传入 https:// 开头的 URL 正常使用自定义仓库，传入 file:// 或本地路径时回退到默认镜像列表