### PR TITLE
fix: 删除 scratchpad fallback 的 bash -c 任意命令执行

### DIFF
--- a/configs/niri/scripts/niri-scratch-toggle.sh
+++ b/configs/niri/scripts/niri-scratch-toggle.sh
@@ -112,7 +112,6 @@ case "$TARGET_APP" in
 
 
     *)
-        # Custom command or script execution
         if [[ "$TARGET_APP" =~ ^~.* ]]; then
             TARGET_APP="${TARGET_APP/#\~/$HOME}"
         fi
@@ -120,13 +119,12 @@ case "$TARGET_APP" in
             TARGET_APP="$HOME/.config/fish/clean-cache"
         fi
 
-        # If it is clean-cache or interactive terminal tool, launch inside floating scratchpad terminal
         if [ "$TARGET_APP" = "$HOME/.config/fish/clean-cache" ] || [[ "$TARGET_APP" == *clean-cache* ]]; then
             niri msg action spawn -- kitty --app-id "scratchpad" -e /bin/bash "$TARGET_APP"
         elif [ -x "$TARGET_APP" ] || command -v "$TARGET_APP" >/dev/null 2>&1; then
             niri msg action spawn -- "$TARGET_APP"
         else
-            niri msg action spawn -- bash -c "$TARGET_APP"
+            echo "Rejected untrusted command: $TARGET_APP" >&2
         fi
         ;;
 esac


### PR DESCRIPTION
危害：niri-scratch-toggle.sh 的 fallback 分支执行 niri msg action spawn bash -c $TARGET_APP，TARGET_APP 来自 orbit launcher 的 TOML 配置 cmd 字段完全未经校验，攻击者在 orbit-items__custom__.toml 中注入恶意 cmd 值可以通过这个 fallback 分支以当前用户权限执行任意 shell 命令

修复方案：删除 fallback 分支的 bash -c 调用，只允许执行可执行文件路径（-x 检查通过）或 command -v 能找到的命令，不满足条件时打印拒绝信息到 stderr 不执行任何操作

校验：bash -n 语法检查通过，可执行文件路径和 PATH 中的命令仍可正常启动，非命令字符串不再被 bash -c 执行