### PR TITLE
fix: orbit 命令注入完整链路修复

### DIFF
--- a/configs/niri/scripts/niri-scratch-toggle.sh
+++ b/configs/niri/scripts/niri-scratch-toggle.sh
@@ -112,21 +112,18 @@ case "$TARGET_APP" in
 
 
     *)
-        # Custom command or script execution
         if [[ "$TARGET_APP" =~ ^~.* ]]; then
             TARGET_APP="${TARGET_APP/#\~/$HOME}"
         fi
         if [ "$TARGET_APP" = "clean-cache" ] && [ -x "$HOME/.config/fish/clean-cache" ]; then
             TARGET_APP="$HOME/.config/fish/clean-cache"
         fi
-
-        # If it is clean-cache or interactive terminal tool, launch inside floating scratchpad terminal
         if [ "$TARGET_APP" = "$HOME/.config/fish/clean-cache" ] || [[ "$TARGET_APP" == *clean-cache* ]]; then
             niri msg action spawn -- kitty --app-id "scratchpad" -e /bin/bash "$TARGET_APP"
         elif [ -x "$TARGET_APP" ] || command -v "$TARGET_APP" >/dev/null 2>&1; then
             niri msg action spawn -- "$TARGET_APP"
         else
-            niri msg action spawn -- bash -c "$TARGET_APP"
+            echo "Rejected untrusted command: $TARGET_APP" >&2
         fi
         ;;
 esac

--- a/configs/niri/scripts/orbit/window.py
+++ b/configs/niri/scripts/orbit/window.py
@@ -346,7 +346,6 @@ class OrbitLauncher(Gtk.Window):
         url = item.get("url", "")
         cmd = item.get("cmd") or item.get("id") or item.get("name", "").lower()
         target_url = url if url else (cmd if cmd.startswith(("http://", "https://", "www.")) else "")
-
         if target_url:
             if target_url.startswith("www."):
                 target_url = "https://" + target_url
@@ -356,11 +355,13 @@ class OrbitLauncher(Gtk.Window):
                 print(f"Error opening URL: {e}", file=sys.stderr)
             self.dismiss_menu()
             return
-
-        # 3. Local Scratchpad / App Command
         script_path = os.path.expanduser("~/.config/niri/scripts/niri-scratch-toggle.sh")
         if not os.path.isfile(script_path):
             script_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "niri-scratch-toggle.sh")
+        if not cmd or any(c in cmd for c in (";", "|", "&", "`", "$", "(", ")", "{", "}", "<", ">", "\n", "\r")):
+            print(f"Rejected unsafe command: {cmd}", file=sys.stderr)
+            self.dismiss_menu()
+            return
         try:
             subprocess.Popen(["/bin/bash", script_path, cmd])
         except Exception as e:


### PR DESCRIPTION
危害：orbit launcher 从 orbit-items__custom__.toml 加载菜单项的 cmd 字段，直接传给 niri-scratch-toggle.sh，脚本 fallback 分支执行 bash -c 将 cmd 作为 shell 命令执行，攻击者在 TOML 配置中注入恶意 cmd 可实现任意代码执行，整条链路从 TOML 读取到 shell 执行没有任何校验

修复方案：双层防御
入口层 window.py 传给脚本前校验 cmd 内容，拒绝包含分号管道符反引号美元符号括号花括号尖括号换行符等 shell 元字符的命令
执行层 niri-scratch-toggle.sh 删除 fallback 分支的 bash -c 调用，只允许执行可执行文件路径或 command -v 能找到的命令，不满足条件时打印拒绝信息到 stderr 不执行任何操作

校验：py_compile 和 bash -n 均通过，包含 shell 元字符的 cmd 在 window.py 被拦截，即使绕过入口校验脚本侧也不再执行 bash -c，正常的 kitty 和 missioncenter 和 wallpaper-picker 等命令不受影响