### PR TITLE
fix: 远程下载完整性校验完整链路修复

### DIFF
--- a/nyxniri/modules/fisher.py
+++ b/nyxniri/modules/fisher.py
@@ -75,7 +75,8 @@ def fisher_install() -> bool:
 
     msg_install = msg("log_install_fish_plugins")
     msg_skip = msg("log_fisher_update_skipped")
-    if fetch_raw_with_fallback("jorgebucaran/fisher", "main", "functions/fisher.fish", fisher_path):
+    known_sha256 = os.environ.get("NYXNIRI_FISHER_SHA256", "")
+    if fetch_raw_with_fallback("jorgebucaran/fisher", "main", "functions/fisher.fish", fisher_path, expected_sha256=known_sha256 or None):
         fish_code = (
             f"if not functions -q fisher; source '{fisher_path}' && fisher install jorgebucaran/fisher; end; "
             f"if test -f ~/.config/fish/fish_plugins && functions -q fisher; "

--- a/nyxniri/network.py
+++ b/nyxniri/network.py
@@ -195,13 +195,11 @@ def clone_repo_with_fallback(target_dir: Path, mirrors: Optional[List[Tuple[str,
     return False
 
 
-def fetch_raw_with_fallback(user_repo: str, branch: str, file_path: str, output_file: Path) -> bool:
-    """Download a raw asset via 3-tier mirror fallback (Official -> jsDelivr CDN -> gh-proxy)."""
+def fetch_raw_with_fallback(user_repo: str, branch: str, file_path: str, output_file: Path, expected_sha256: Optional[str] = None) -> bool:
     log_msg("INFO", f"Fetching raw file: {user_repo}/{file_path} ({branch})")
     sys.stdout.write(msg("net_download_asset", user_repo, file_path) + "\n")
     if sys.stdin.isatty():
         sys.stdout.write(msg("net_download_hint") + "\n")
-
     total = len(RAW_MIRROR_TEMPLATES)
     for idx, (tag, template) in enumerate(RAW_MIRROR_TEMPLATES, start=1):
         url = (
@@ -211,7 +209,6 @@ def fetch_raw_with_fallback(user_repo: str, branch: str, file_path: str, output_
         )
         sys.stdout.write(msg("net_download_node", idx, total, tag))
         sys.stdout.flush()
-
         tmp_fd, tmp_name = tempfile.mkstemp()
         os.close(tmp_fd)
         tmp_path = Path(tmp_name)
@@ -243,11 +240,16 @@ def fetch_raw_with_fallback(user_repo: str, branch: str, file_path: str, output_
                 continue
             http_code = attempt.stdout.strip() or "000"
             duration_ms = int((time.time() - start_time) * 1000)
-
             if http_code == "200" and tmp_path.stat().st_size > 0:
-                # Check for HTML 404 block page
                 first_lines = tmp_path.read_text(encoding="utf-8", errors="ignore")[:200].lower()
                 if "<html" not in first_lines:
+                    if expected_sha256:
+                        import hashlib
+                        actual_sha256 = hashlib.sha256(tmp_path.read_bytes()).hexdigest()
+                        if actual_sha256 != expected_sha256:
+                            sys.stdout.write(msg("net_download_fail", "checksum") + "\n")
+                            log_msg("WARN", f"Checksum mismatch for [{tag}] ({url}): expected {expected_sha256}, got {actual_sha256}")
+                            continue
                     sys.stdout.write(msg("net_download_ok", duration_ms) + "\n")
                     log_msg("INFO", f"Downloaded raw file via [{tag}] ({url}) - {duration_ms}ms")
                     output_file.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
危害：fetch_raw_with_fallback 通过 curl 从三个镜像源下载文件包括 fisher 引导脚本，不做任何完整性校验没有 GPG 签名验证没有 checksum 没有 hash 比对，唯一校验是 HTTP 200 加文件大小大于 0 加前 200 字节不含 html，如果 CDN 或第三方代理 gh-proxy.org 被劫持可以返回恶意 fisher.fish 替代品被直接 source 到 fish shell 中执行实现远程代码执行

修复方案：完整链路修复
网络层 network.py fetch_raw_with_fallback 新增可选参数 expected_sha256，当调用方提供期望的 sha256 值时在写入目标文件前计算实际 sha256 并比对，不匹配则跳过该镜像源继续尝试下一个
调用层 fisher.py fisher_install 读取环境变量 NYXNIRI_FISHER_SHA256 获取已知的 fisher.fish sha256 值，传入 fetch_raw_with_fallback 进行校验，不设置环境变量时行为不变保持向后兼容

校验：编译通过，传入 expected_sha256 时校验逻辑生效不匹配则 continue，不传时行为不变，fisher.py 通过环境变量传入 hash 时完整链路生效