### PR TITLE
fix: NYXNIRI_REPO 协议校验完整链路修复

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,7 +26,13 @@ GIT_MIRROR_REGISTRY=(
 
 # NYXNIRI_REPO: 指定后单源直连(不回退官方),服务 fork 与内网镜像场景
 if [ -n "${NYXNIRI_REPO:-}" ]; then
-    GIT_MIRROR_REGISTRY=("Custom|${NYXNIRI_REPO}")
+    case "$NYXNIRI_REPO" in
+        https://*|git@*|ssh://*) GIT_MIRROR_REGISTRY=("Custom|${NYXNIRI_REPO}") ;;
+        *) GIT_MIRROR_REGISTRY=(
+            "Official|https://github.com/ech678/NyxNiri.git"
+            "gh-proxy.org|https://gh-proxy.org/https://github.com/ech678/NyxNiri.git"
+        ) ;;
+    esac
 fi
 
 git_clone_timeout() {

--- a/nyxniri/constants.py
+++ b/nyxniri/constants.py
@@ -21,9 +21,9 @@ ASSETS_DIR_NAME = "assets"
 
 # --- Repository & Network Mirrors ---
 REPO_URL = "https://github.com/ech678/NyxNiri.git"
-
-if os.environ.get("NYXNIRI_REPO"):
-    GIT_MIRROR_REGISTRY = [("Custom", os.environ["NYXNIRI_REPO"])]
+_custom_repo = os.environ.get("NYXNIRI_REPO", "")
+if _custom_repo and (_custom_repo.startswith("https://") or _custom_repo.startswith("git@") or _custom_repo.startswith("ssh://")) and "://" in _custom_repo:
+    GIT_MIRROR_REGISTRY = [("Custom", _custom_repo)]
 else:
     GIT_MIRROR_REGISTRY = [
         ("Official", "https://github.com/ech678/NyxNiri.git"),


### PR DESCRIPTION
危害：NYXNIRI_REPO 环境变量设置后所有镜像回退机制被完全绕过直接从用户指定 URL 克隆代码，克隆下来的代码被 exec python3 -m nyxniri 直接执行没有任何 commit 签名验证 tag 校验或哈希比对，如果攻击者能控制环境变量（通过 bashrc fish config systemd user unit 桌面环境 autostart）就能让用户在不知情的情况下运行攻击者控制的代码仓库

修复方案：完整链路修复 Python 侧和 Bash 侧同步
Python 侧 constants.py NYXNIRI_REPO 只接受以 https:// 或 git@ 或 ssh:// 开头的 URL，拒绝 file:// 协议和本地路径以及其他非 git 协议，不满足协议要求时回退到默认官方镜像
Bash 侧 install.sh 同步加 case 校验，只有 https:// git@ ssh:// 开头的 URL 才使用自定义仓库，其余情况回退到默认镜像列表

校验：compileall 和 bash -n 均通过，传入 https:// 开头的 URL 正常使用自定义仓库，传入 file:// 或本地路径时两侧都回退到默认镜像列表