### PR TITLE
fix: orbit PID 文件注入导致任意进程被 kill

### DIFF
--- a/configs/niri/scripts/orbit/lock.py
+++ b/configs/niri/scripts/orbit/lock.py
@@ -8,9 +8,18 @@ import sys
 import signal
 import fcntl
 
+def _is_orbit_process(pid: int) -> bool:
+    try:
+        cmdline_path = f"/proc/{pid}/cmdline"
+        if not os.path.isfile(cmdline_path):
+            return False
+        with open(cmdline_path, "rb") as f:
+            cmdline = f.read().decode("utf-8", errors="ignore").replace("\x00", " ")
+        return "orbit" in cmdline.lower() or "scratch" in cmdline.lower()
+    except Exception:
+        return False
 
 def acquire_instance_lock(lock_path: str, pid_path: str) -> int:
-    """Acquire single-instance file lock. Toggle-close existing instance if detected."""
     try:
         lock_fd = os.open(lock_path, os.O_CREAT | os.O_RDWR, 0o600)
         fcntl.flock(lock_fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
@@ -18,23 +27,24 @@ def acquire_instance_lock(lock_path: str, pid_path: str) -> int:
         if os.path.isfile(pid_path):
             try:
                 with open(pid_path, "r") as pf:
-                    old_pid = int(pf.read().strip())
+                    raw = pf.read().strip()
+                if not raw.isdigit():
+                    sys.exit(0)
+                old_pid = int(raw)
+                if old_pid <= 1 or not _is_orbit_process(old_pid):
+                    sys.exit(0)
                 os.kill(old_pid, signal.SIGTERM)
             except Exception:
                 pass
         sys.exit(0)
-
     try:
         with open(pid_path, "w") as pf:
             pf.write(str(os.getpid()))
     except Exception:
         pass
-
     return lock_fd
 
-
 def release_instance_lock(lock_fd: int, pid_path: str):
-    """Release file lock and clean up PID file."""
     try:
         if os.path.isfile(pid_path):
             os.remove(pid_path)


### PR DESCRIPTION
危害：orbit launcher 的 lock.py 从 PID 文件读取 PID 然后 os.kill 发送 SIGTERM，PID 文件内容完全未校验，路径固定可预测（XDG_RUNTIME_DIR/nyxniri-orbit-launcher.pid），攻击者写入任意 PID 到该文件后用户下次按 Super+A 打开 Orbit Launcher 会向任意进程发送 SIGTERM 导致拒绝服务甚至终止关键系统进程

修复方案：完整链路修复
新增 _is_orbit_process 校验函数：读取 /proc/PID/cmdline 检查是否包含 orbit 或 scratch 关键字，确认目标进程确实是 orbit launcher 实例
acquire_instance_lock 读取 PID 文件时三层校验：raw 必须是纯数字、PID 必须大于 1、_is_orbit_process 必须返回 True，任一校验失败直接 sys.exit 不发送信号
调用方 orbit-launcher.py 和 niri-scratch-menu.py 无需改动，它们传递的路径参数不变，安全校验在 lock.py 集中完成

校验：py_compile 通过，注入非数字 PID 时 sys.exit 不 kill，注入数字但非 orbit 进程的 PID 时 sys.exit 不 kill，正常 orbit 实例的 PID 仍能正确 toggle close