### PR TITLE
feat: 壁纸选择器按色调分类

### DIFF
--- a/configs/niri/scripts/wallpaper_picker/palette.py
+++ b/configs/niri/scripts/wallpaper_picker/palette.py
@@ -67,3 +67,35 @@ def load_material_palette() -> dict:
     sr, sg, sb = palette["surface"]
     palette["is_dark"] = (0.299 * sr + 0.587 * sg + 0.114 * sb < 0.5)
     return palette
+
+
+TONE_COLORS = {
+    "Red": "#e5484d",
+    "Orange": "#f76b15",
+    "Yellow": "#ffb224",
+    "Green": "#46a758",
+    "Teal": "#12a594",
+    "Blue": "#0090ff",
+    "Purple": "#8e4ec6",
+    "Pink": "#d6409f",
+    "Mono": "#9a9aa5",
+}
+
+
+def hue_to_tone(h: float) -> str:
+    deg = (h % 1.0) * 360.0
+    if deg >= 345.0 or deg < 15.0:
+        return "Red"
+    if deg < 45.0:
+        return "Orange"
+    if deg < 70.0:
+        return "Yellow"
+    if deg < 165.0:
+        return "Green"
+    if deg < 205.0:
+        return "Teal"
+    if deg < 260.0:
+        return "Blue"
+    if deg < 300.0:
+        return "Purple"
+    return "Pink"

--- a/configs/niri/scripts/wallpaper_picker/scanner.py
+++ b/configs/niri/scripts/wallpaper_picker/scanner.py
@@ -9,19 +9,56 @@ cost nothing and releasing happens automatically when the card scrolls away.
 
 import os
 import sys
-import hashlib
-import subprocess
+import math
 import uuid
+import hashlib
+import colorsys
+import subprocess
 from concurrent.futures import ThreadPoolExecutor
 import gi
 gi.require_version("GLib", "2.0")
 gi.require_version("GdkPixbuf", "2.0")
 from gi.repository import GLib, GdkPixbuf
 
+from .palette import TONE_COLORS, hue_to_tone
 from .config import (
     STATIC_EXTENSIONS, VIDEO_EXTENSIONS, ALL_SUPPORTED_EXTENSIONS,
     CACHE_DIR, get_wallpaper_search_roots
 )
+
+
+def analyze_image_tone(thumb_path: str):
+    try:
+        pix = GdkPixbuf.Pixbuf.new_from_file_at_scale(thumb_path, 64, 36, True)
+        data = pix.get_pixels()
+        n_ch = 4 if pix.get_has_alpha() else max(pix.get_n_channels(), 3)
+        rowstride = pix.get_rowstride()
+        w, h = pix.get_width(), pix.get_height()
+        sin_sum = cos_sum = weight_sum = 0.0
+        sampled = 0
+        for y in range(h):
+            row_off = y * rowstride
+            for x in range(w):
+                o = row_off + x * n_ch
+                r = data[o] / 255.0
+                g = data[o + 1] / 255.0
+                b = data[o + 2] / 255.0
+                hue, sat, val = colorsys.rgb_to_hsv(r, g, b)
+                sampled += 1
+                if sat < 0.14 or val < 0.06:
+                    continue
+                weight = sat * (0.3 + 0.7 * val)
+                angle = hue * 6.283185307179586
+                sin_sum += math.sin(angle) * weight
+                cos_sum += math.cos(angle) * weight
+                weight_sum += weight
+        if sampled == 0:
+            return None
+        if weight_sum < sampled * 0.18:
+            return "Mono"
+        return hue_to_tone(math.atan2(sin_sum, cos_sum) / 6.283185307179586)
+    except Exception:
+        return None
 
 
 class WallpaperItem:
@@ -48,6 +85,8 @@ class WallpaperItem:
         self.hash_id = hashlib.md5(raw_key).hexdigest()
         self.thumb_path = os.path.join(CACHE_DIR, f"{self.hash_id}.jpg")
         self.is_loading = False
+        self.tone = None
+        self.tone_queued = False
 
 
 class WallpaperScanner:
@@ -56,11 +95,13 @@ class WallpaperScanner:
     def __init__(self, on_thumb_ready_cb=None):
         self.on_thumb_ready_cb = on_thumb_ready_cb
         self.items = []
-        self.categories = ["All", "Static", "Live"]
-        self.category_items = {"All": [], "Static": [], "Live": []}
+        self.categories = ["All", "Static", "Live"] + list(TONE_COLORS)
+        self.category_items = {cat: [] for cat in self.categories}
+        self.tone_items = {tone: [] for tone in TONE_COLORS}
         self.executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="wp_thumb")
         os.makedirs(CACHE_DIR, exist_ok=True)
         self._lazy_loaded = False
+        self.on_tone_assigned_cb = None
 
     def scan(self) -> list:
         """Scan all resolved search roots and subdirectories."""
@@ -106,7 +147,7 @@ class WallpaperScanner:
 
         # Build categories list: primary tabs + actual custom user subfolders
         sorted_subfolders = sorted(list(custom_subfolders), key=lambda x: x.lower())
-        self.categories = ["All", "Static", "Live"] + sorted_subfolders
+        self.categories = ["All", "Static", "Live"] + list(TONE_COLORS) + sorted_subfolders
         self.category_items = {cat: [] for cat in self.categories}
 
         for item in self.items:
@@ -160,6 +201,36 @@ class WallpaperScanner:
         """Notify the UI (on main thread) that a thumbnail file is available."""
         if self.on_thumb_ready_cb:
             self.on_thumb_ready_cb(item)
+        if item.tone is None and not item.tone_queued:
+            item.tone_queued = True
+            self.executor.submit(self._tone_worker, item)
+
+    def _tone_assigned(self, item: WallpaperItem):
+        if self.on_tone_assigned_cb:
+            self.on_tone_assigned_cb(item)
+        return GLib.SOURCE_REMOVE
+
+    def analyze_all_tones(self):
+        """Queue tone analysis for every item that still lacks one (tone-tab click)."""
+        for item in self.items:
+            if item.tone is None and not item.tone_queued:
+                item.tone_queued = True
+                self.executor.submit(self._tone_worker, item)
+
+    def _tone_worker(self, item: WallpaperItem):
+        try:
+            if item.tone is not None:
+                return
+            if not os.path.isfile(item.thumb_path):
+                self._generate_thumbnail_worker(item)
+            if item.tone is None and os.path.isfile(item.thumb_path):
+                tone = analyze_image_tone(item.thumb_path)
+                item.tone = tone or ""
+                if tone:
+                    self.tone_items[tone].append(item)
+                GLib.idle_add(self._tone_assigned, item)
+        except Exception:
+            item.tone = ""
 
     def _generate_thumbnail_worker(self, item: WallpaperItem):
         item.is_loading = True

--- a/configs/niri/scripts/wallpaper_picker/window.py
+++ b/configs/niri/scripts/wallpaper_picker/window.py
@@ -22,7 +22,7 @@ gi.require_version("Gdk", "3.0")
 gi.require_version("Pango", "1.0")
 from gi.repository import Gtk, Gdk, GtkLayerShell, GLib, Pango
 
-from .palette import load_material_palette
+from .palette import load_material_palette, TONE_COLORS
 from .lock import release_instance_lock
 from .config import (
     WIN_WIDTH, WIN_HEIGHT, WIN_RADIUS,
@@ -117,6 +117,16 @@ def _build_m3_css(palette: dict) -> str:
 
     /* ── M3 filter chips ── */
     .chips {{ spacing: 8px; }}
+    .chips-scroll {{
+        background-color: transparent;
+        border: none;
+    }}
+    .chips-scroll scrollbar slider {{
+        background-color: {_rgba(primary, 0.45)};
+        border-radius: 2px;
+        min-height: 3px;
+        min-width: 28px;
+    }}
     .chip {{
         background-color: {chip_bg_idle};
         border: 1px solid {outline_idle};
@@ -184,7 +194,17 @@ def _build_m3_css(palette: dict) -> str:
         font-size: 9.5pt;
         margin-right: 4px;
     }}
-
+    .tone-dot {{
+        min-width: 8px;
+        min-height: 8px;
+        border-radius: 4px;
+        margin-left: 6px;
+        border: 1px solid {_rgba(outline, 0.30)};
+    }}
+""" + "".join(
+        f"\n    .tone-dot.{tone} {{ background-color: {color}; }}"
+        for tone, color in TONE_COLORS.items()
+    ) + f"""
     /* ── M3 scrollbar ── */
     .grid-scroll {{ background-color: transparent; border: none; }}
     .grid-scroll scrollbar {{ background-color: transparent; }}
@@ -216,10 +236,12 @@ class WallpaperPickerWindow(Gtk.Window):
         self.is_dismissing = False
         self._dismiss_timer = None
         self.thumb_widgets = {}      # hash_id -> thumb Gtk.Box
+        self.tone_dots = {}
         self._applied_thumbs = set() # hash_ids that already got a CSS provider
 
         # Scanner and data
         self.scanner = WallpaperScanner(on_thumb_ready_cb=self.on_thumb_ready)
+        self.scanner.on_tone_assigned_cb = self.on_tone_assigned
         self.scanner.scan()
         self.current_wp_path = self.scanner.get_current_wallpaper()
 
@@ -303,6 +325,10 @@ class WallpaperPickerWindow(Gtk.Window):
         dialog.pack_start(header, False, False, 0)
 
         # Category chips (M3 filter chips, single-active radio group)
+        chips_scroll = Gtk.ScrolledWindow()
+        chips_scroll.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.NEVER)
+        chips_scroll.set_min_content_height(36)
+        chips_scroll.get_style_context().add_class("chips-scroll")
         chips = Gtk.Box(orientation=Gtk.Orientation.HORIZONTAL, spacing=8)
         chips.get_style_context().add_class("chips")
         self.chip_buttons = []
@@ -314,7 +340,8 @@ class WallpaperPickerWindow(Gtk.Window):
             btn.connect("toggled", self.on_chip_toggled, idx)
             chips.pack_start(btn, False, False, 0)
             self.chip_buttons.append(btn)
-        dialog.pack_start(chips, False, False, 0)
+        chips_scroll.add(chips)
+        dialog.pack_start(chips_scroll, False, False, 0)
 
         # Card grid (native FlowBox: lazy render + kinetic scroll + arrow nav)
         self.flowbox = Gtk.FlowBox()
@@ -372,6 +399,14 @@ class WallpaperPickerWindow(Gtk.Window):
         title_lbl.set_ellipsize(Pango.EllipsizeMode.END)
         title_lbl.set_max_width_chars(28)
         info.pack_start(title_lbl, False, False, 0)
+        tone_dot = Gtk.Box()
+        tone_dot.get_style_context().add_class("tone-dot")
+        tone_dot.set_valign(Gtk.Align.CENTER)
+        tone_dot.set_halign(Gtk.Align.END)
+        tone_dot.set_hexpand(True)
+        tone_dot.set_no_show_all(True)
+        self.tone_dots[item.hash_id] = tone_dot
+        info.pack_end(tone_dot, False, False, 0)
         inner.pack_start(info, False, False, 0)
 
         child.add(inner)
@@ -411,6 +446,8 @@ class WallpaperPickerWindow(Gtk.Window):
             return not item.is_video
         if cat == "Live":
             return item.is_video
+        if cat in self.scanner.tone_items:
+            return item.tone == cat
         return item.category == cat
 
     def _visible_children(self):
@@ -462,6 +499,32 @@ class WallpaperPickerWindow(Gtk.Window):
         cat = self.scanner.categories[idx]
         if cat != "All":
             self.scanner.load_category_thumbnails(cat)
+        if cat in self.scanner.tone_items:
+            self.scanner.analyze_all_tones()
+            self._sync_visible_tone_dots()
+
+    def on_tone_assigned(self, item):
+        self._show_tone_dot(item)
+        if self.scanner.categories[self.active_cat_idx] in self.scanner.tone_items:
+            self.flowbox.invalidate_filter()
+            self._refresh_count()
+
+    def _show_tone_dot(self, item):
+        dot = self.tone_dots.get(item.hash_id)
+        if not dot or not item.tone:
+            return
+        sc = dot.get_style_context()
+        for cls in list(TONE_COLORS) + ["unknown"]:
+            sc.remove_class(cls)
+        sc.add_class(item.tone)
+        dot.set_tooltip_text(item.tone)
+        dot.show()
+
+    def _sync_visible_tone_dots(self):
+        for child in self.flowbox.get_children():
+            item = child.item
+            if item.tone:
+                self._show_tone_dot(item)
 
     def on_child_activated(self, box, child):
         self.select_and_apply(child.item)

--- a/configs/niri/scripts/wallpaper_picker/window.py
+++ b/configs/niri/scripts/wallpaper_picker/window.py
@@ -259,6 +259,8 @@ class WallpaperPickerWindow(Gtk.Window):
         visual = self.get_screen().get_rgba_visual()
         if visual:
             self.set_visual(visual)
+        else:
+            self.set_app_paintable(False)
 
         # ── Material You CSS ──
         try:
@@ -383,6 +385,7 @@ class WallpaperPickerWindow(Gtk.Window):
 
         thumb = Gtk.Box()
         thumb.get_style_context().add_class("thumb")
+        thumb.set_size_request(int(CARD_WIDTH), int(THUMB_HEIGHT))
         inner.pack_start(thumb, False, False, 0)
         self.thumb_widgets[item.hash_id] = thumb
         # Thumbnail is applied later via on_thumb_ready (single path, dedup'd),


### PR DESCRIPTION
给壁纸选择器加了按色调分类的能力
缩略图生成后会自动做一次色调分析，取 HSV 圆形均值再按饱和度和亮度加权，色相映射到 Red、Orange、Yellow、Green、Teal、Blue、Purple、Pink 九档，低饱和的图归入 Mono
分类行里新增对应的色调 chips，点选后只显示该色调的壁纸
每张卡片右上角有一个对应色调的色点，鼠标悬停可以看色调名
分析走原有的后台线程池，缩略图命中缓存或者懒加载时同样会补上色调，不会阻塞界面