### PR TITLE
feat: 非Arch发行版引导与安装后的速查入口

### DIFF
--- a/nyxniri/cli.py
+++ b/nyxniri/cli.py
@@ -201,6 +201,10 @@ def _phase_preflight_check(
 
 def install_configs_workflow(mode: str = "full") -> bool:
     """Full execution pipeline for dotfiles, dependencies, wallpapers, and optional modules."""
+    if mode == "full" and not shutil.which("pacman"):
+        print(msg("distro_unsupported"))
+        print(msg("distro_unsupported_hint"))
+        return True
     if sys.stdin.isatty():
         chosen_dict = run_master_component_menu(is_update=False, mode=mode)
         if not chosen_dict:
@@ -492,6 +496,9 @@ def deps_menu_loop() -> None:
     """Dependencies & Recommended apps submenu."""
     if not sys.stdin.isatty():
         print(msg("interactive_terminal_required"), file=sys.stderr)
+        return
+    if not shutil.which("pacman"):
+        print(msg("deps_menu_unsupported"))
         return
 
     while True:

--- a/nyxniri/deploy/deploy.py
+++ b/nyxniri/deploy/deploy.py
@@ -221,7 +221,7 @@ def render_completion_screen(
         _render_body()
         sys.stdout.write(f"\n  {Colors.BOLD_WHITE}{msg('summary_section_next')}{Colors.RESET}\n")
         sys.stdout.write(f"    {msg('summary_next_start')}\n")
-        sys.stdout.write(f"    {msg('summary_next_manual')}\n")
+        sys.stdout.write(f"    {msg('summary_next_help')}\n")
         sys.stdout.write(f"    {msg('summary_next_panel')}\n\n")
         return
 

--- a/nyxniri/i18n.py
+++ b/nyxniri/i18n.py
@@ -419,9 +419,25 @@ TRANSLATIONS: Dict[str, Dict[str, str]] = {
         "zh": "速查手册 : 运行 nyxhelp",
         "en": "Quick Manual  : Run nyxhelp",
     },
+    "summary_next_help": {
+        "zh": "速查手册 : 运行 nyxhelp，按键和命令都有",
+        "en": "Quick Manual  : Run nyxhelp for keys and commands",
+    },
     "summary_next_panel": {
         "zh": "控制面板 : 运行 nyxniri",
         "en": "Control Panel : Run nyxniri",
+    },
+    "distro_unsupported": {
+        "zh": "[!] 未检测到 pacman，当前系统不是 Arch 系发行版",
+        "en": "[!] pacman not found: this does not look like an Arch-based distribution",
+    },
+    "distro_unsupported_hint": {
+        "zh": "NyxNiri 的依赖安装依赖 pacman 与 AUR，在别的发行版上无法自动完成。配置文件本身仍可手动取用：仓库 configs/ 目录下的内容按普通 dotfiles 的方式复制到 ~/.config 即可，壁纸在 assets/wallpapers。欢迎来仓库 Issue 说说你的发行版，人多了会考虑支持。",
+        "en": "NyxNiri installs its dependencies through pacman and the AUR, which is not available here. You can still take the configs manually: copy whatever you need from the configs/ directory in the repository into ~/.config like ordinary dotfiles, wallpapers live in assets/wallpapers. Feel free to open an Issue and tell us your distro, support may come if there is demand.",
+    },
+    "deps_menu_unsupported": {
+        "zh": "[!] 未检测到 pacman，依赖菜单仅适用于 Arch 系发行版。配置可以手动从仓库 configs/ 复制到 ~/.config 使用。",
+        "en": "[!] pacman not found: the dependency menus only apply to Arch-based systems. You can still copy configs manually from the repository configs/ directory into ~/.config.",
     },
 
     # Summary action card


### PR DESCRIPTION
新用户审计发现非Arch发行版的用户走完整安装流程会在依赖安装阶段大量报错，全程得不到一句明确的解释，deps菜单也会尝试在别的发行版上引导安装paru
现在install full在没检测到pacman的时候会直接给出说明，告诉用户依赖自动化只适用于Arch系，配置可以按普通dotfiles的方式从configs目录手动取用，壁纸在assets里，也欢迎反馈自己的发行版
deps和apps菜单同样前置拦截，一句话说明适用范围，不再引导到必然失败的流程
安装完成的下一步里新增一条nyxhelp速查手册入口，新用户装完知道哪里有按键和命令的清单
Arch用户的流程一行未动，install config模式也不受影响