### PR TITLE
feat: 护眼模式柔和过渡与观感打磨

### DIFF
--- a/configs/niri/effects_eyecare.kdl
+++ b/configs/niri/effects_eyecare.kdl
@@ -1,6 +1,6 @@
-// 护眼模式：禁用毛玻璃 Blur，窗口 100% 纯不透明（消除穿透与眩光）
+// 护眼模式
 window-rule {
-    opacity 1.0
+    opacity 0.96
     background-effect {
         blur false
         xray false
@@ -9,7 +9,7 @@ window-rule {
 
 window-rule {
     match is-focused=false
-    opacity 1.0
+    opacity 0.94
 }
 
 blur {

--- a/configs/niri/scripts/toggle-eyecare.sh
+++ b/configs/niri/scripts/toggle-eyecare.sh
@@ -24,6 +24,8 @@ EYECARE_EFFECTS="$NIRI_DIR/effects_eyecare.kdl"
 
 # Desired EyeCare warm color temperature (in Kelvin: 5500K for subtle natural warmth)
 EYECARE_TEMP=5500
+RAMP_SECONDS=1.5
+RAMP_PID_FILE="${XDG_RUNTIME_DIR:-/tmp}/nyxniri-eyecare-ramp.pid"
 
 # Log for reload failures / self-healing events (empty on success)
 LOG_FILE="${XDG_RUNTIME_DIR:-/tmp}/nyxniri-eyecare.log"
@@ -89,7 +91,7 @@ if [ "${1:-}" = "--sync" ]; then
     pkill -x wlsunset 2>/dev/null || true
     if [ "$CURRENTLY_ON" = "true" ]; then
         if command -v wlsunset >/dev/null 2>&1; then
-            nohup wlsunset -T 6500 -t "$EYECARE_TEMP" -d 0.3 -S 00:00 -s 00:00 >/dev/null 2>&1 9>&- &
+            nohup wlsunset -T 6500 -t "$EYECARE_TEMP" -d "$RAMP_SECONDS" -S 00:00 -s 00:00 >/dev/null 2>&1 9>&- &
         fi
     fi
     exit 0
@@ -100,6 +102,10 @@ if [ "$HAS_NOCTALIA" = "true" ]; then
     noctalia msg nightlight-disable 2>/dev/null || true
 fi
 pkill -x wlsunset 2>/dev/null || true
+if [ -f "$RAMP_PID_FILE" ]; then
+    kill "$(cat "$RAMP_PID_FILE" 2>/dev/null)" 2>/dev/null || true
+    rm -f "$RAMP_PID_FILE"
+fi
 
 IS_TURNING_ON=false
 
@@ -112,15 +118,29 @@ else
     IS_TURNING_ON=true
 fi
 
-# 3. Smoothly ramp color temperature over 0.3s without GPU pipeline tearing
+ramp_temp() {
+    local from="$1" to="$2"
+    local steps=12 i t
+    (
+        echo $$ > "$RAMP_PID_FILE"
+        for i in $(seq 1 "$steps"); do
+            t=$(( from + (to - from) * i / steps ))
+            pkill -x wlsunset 2>/dev/null || true
+            nohup wlsunset -T "$t" -t "$t" -S 00:00 -s 23:59 >/dev/null 2>&1 9>&- &
+            sleep 0.12
+        done
+        if [ "$to" -ge 6400 ]; then
+            pkill -x wlsunset 2>/dev/null || true
+        fi
+        rm -f "$RAMP_PID_FILE"
+    ) &
+}
+
 if [ "$IS_TURNING_ON" = "true" ]; then
     sleep 0.05
-    nohup wlsunset -T 6500 -t "$EYECARE_TEMP" -d 0.3 -S 00:00 -s 00:00 >/dev/null 2>&1 9>&- &
-fi
-
-# 4. Visual Notification
-if [ "$IS_TURNING_ON" = "true" ]; then
+    ramp_temp 6500 "$EYECARE_TEMP"
     notify-send -t 2000 "Eye Care : On"
 else
+    ramp_temp "$EYECARE_TEMP" 6400
     notify-send -t 2000 "Eye Care : Off"
 fi

--- a/configs/niri/scripts/toggle-eyecare.sh
+++ b/configs/niri/scripts/toggle-eyecare.sh
@@ -24,7 +24,6 @@ EYECARE_EFFECTS="$NIRI_DIR/effects_eyecare.kdl"
 
 # Desired EyeCare warm color temperature (in Kelvin: 5500K for subtle natural warmth)
 EYECARE_TEMP=5500
-RAMP_SECONDS=1.5
 RAMP_PID_FILE="${XDG_RUNTIME_DIR:-/tmp}/nyxniri-eyecare-ramp.pid"
 
 # Log for reload failures / self-healing events (empty on success)
@@ -89,10 +88,8 @@ if [ "${1:-}" = "--sync" ]; then
         noctalia msg nightlight-disable 2>/dev/null || true
     fi
     pkill -x wlsunset 2>/dev/null || true
-    if [ "$CURRENTLY_ON" = "true" ]; then
-        if command -v wlsunset >/dev/null 2>&1; then
-            nohup wlsunset -T 6500 -t "$EYECARE_TEMP" -d "$RAMP_SECONDS" -S 00:00 -s 00:00 >/dev/null 2>&1 9>&- &
-        fi
+    if [ "$CURRENTLY_ON" = "true" ] && command -v wlsunset >/dev/null 2>&1; then
+        ramp_temp 6500 "$EYECARE_TEMP"
     fi
     exit 0
 fi
@@ -120,16 +117,16 @@ fi
 
 ramp_temp() {
     local from="$1" to="$2"
-    local steps=12 i t
+    local steps=14 i t
     (
         echo $$ > "$RAMP_PID_FILE"
         for i in $(seq 1 "$steps"); do
-            t=$(( from + (to - from) * i / steps ))
+            t=$(awk -v a="$from" -v b="$to" -v i="$i" -v n="$steps" 'BEGIN{x=i/n; e=x*x*(3-2*x); printf "%d", a+(b-a)*e}')
             pkill -x wlsunset 2>/dev/null || true
             nohup wlsunset -T "$t" -t "$t" -S 00:00 -s 23:59 >/dev/null 2>&1 9>&- &
-            sleep 0.12
+            sleep 0.11
         done
-        if [ "$to" -ge 6400 ]; then
+        if [ "$to" -ge 6500 ]; then
             pkill -x wlsunset 2>/dev/null || true
         fi
         rm -f "$RAMP_PID_FILE"
@@ -139,8 +136,8 @@ ramp_temp() {
 if [ "$IS_TURNING_ON" = "true" ]; then
     sleep 0.05
     ramp_temp 6500 "$EYECARE_TEMP"
-    notify-send -t 2000 "Eye Care : On"
+    notify-send -t 2000 -i weather-clear-night "Eye Care" "on · 5500K"
 else
-    ramp_temp "$EYECARE_TEMP" 6400
-    notify-send -t 2000 "Eye Care : Off"
+    ramp_temp "$EYECARE_TEMP" 6500
+    notify-send -t 2000 -i weather-clear "Eye Care" "off"
 fi


### PR DESCRIPTION
现在的护眼切换是透明度从零点九直接跳到一，毛玻璃整个关闭，色温在零点三秒内打满，三件事同时瞬间发生，观感像被人拔了显示器电源
查证发现色温渐变参数在固定日出日落时刻下根本不生效，实际一直是瞬时跳变
这次改成透明度只微降到零点九六，非焦点零点九四，保住挡眩光的核心诉求又不拆掉视觉层次
色温改为后台子进程分十四步手动步进，每步用平滑曲线插值，开头轻中间顺结尾缓，总时长约一点五秒，关闭时反向回暖
开机自启同步护眼状态时走同样的缓动，登录不再一进桌面就定死暖色
快速连按有锁和进程记录双保险不会打架
通知加了图标和色温读数，文案精简
护眼的护眼效果不变，变的是进入和离开的方式