### PR TITLE
fix(wallpaper-picker): 带透明通道(RGBA)的图片缩略图生成失败

### DIFF
--- a/configs/niri/scripts/wallpaper_picker/scanner.py
+++ b/configs/niri/scripts/wallpaper_picker/scanner.py
@@ -181,6 +181,15 @@ class WallpaperScanner:
                 else:
                     try:
                         pix = GdkPixbuf.Pixbuf.new_from_file_at_scale(item.path, 480, 270, True)
+                        # JPEG 不支持 alpha 通道（glycin 编码器会拒绝 Rgba8），
+                        # 带透明的图先合成到不透明黑底上再存
+                        if pix.get_has_alpha():
+                            flat = GdkPixbuf.Pixbuf.new(GdkPixbuf.Colorspace.RGB, False, 8,
+                                                        pix.get_width(), pix.get_height())
+                            flat.fill(0x000000)
+                            pix.composite(flat, 0, 0, flat.get_width(), flat.get_height(),
+                                          0, 0, 1, 1, GdkPixbuf.InterpType.BILINEAR, 255)
+                            pix = flat
                         pix.savev(item.thumb_path, "jpeg", ["quality"], ["85"])
                     except Exception as e:
                         print(f"Thumbnail generation error on {item.filename}: {e}", file=sys.stderr)


### PR DESCRIPTION
## 问题

在较新的 GdkPixbuf（glycin 沙箱图像加载框架）栈上，`Pixbuf.savev(..., "jpeg")` 对带 alpha 通道的图片会直接失败：

```
gi.repository.GLib.GError: gly-loader-error: Remote error:
org.gnome.glycin.Error.InternalEditorError:
glycin-loaders/glycin-image-rs/src/editor.rs:127:22:
Internal error: The encoder or decoder for Jpeg does not support the color type `Rgba8`
```

**表现**：壁纸选择器中所有带透明通道的图片（典型如 wallhaven 下载的 PNG）缩略图全部空白，`~/.cache/nyxniri/thumbnails/` 里也不会生成对应缓存；不带 alpha 的 webp 正常。

## 修复

`scanner.py` 的 `_generate_thumbnail_worker` 图片分支：保存前检测 `get_has_alpha()`，若带透明通道则先 `composite` 到一张不透明 RGB 底板（黑底）上，再存 JPEG。

## 验证

- CachyOS（kernel 7.2.2 / python 3.14 / glycin 栈）实测
- 修复前：RGBA PNG 100% 复现上述报错，缩略图空白
- 修复后：同一张图成功生成 480x270 JPEG；重开选择器后全部壁纸预览正常

感谢你的作品 🎉