### PR TITLE
feat(niri): 支持 Material You 动态聚焦光晕并完善 sapphire-blue 昼夜自适应

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@
 ## [Unreleased]
 
 ### Added
-- Niri 新增 glow 预设
+- Niri 新增 sapphire-blue 预设：宝石蓝聚焦光晕（`#1a73e8`，2px 轮廓与 28px 柔和弥散光晕）
+- Niri 新增 material-you 预设：聚焦光晕颜色跟随当前配色
 - 主页文档新增自定义配置与模块化引入的实用速查
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -127,7 +127,8 @@ Built-in official presets:
   - `transparent`: 75% higher translucency flavor
 - **`niri`**:
   - `default`: minimalist frameless look (default)
-  - `glow`: enables 2px outline and 28px soft diffused ambient glow (improves focus visibility across tiled windows)
+  - `sapphire-blue`: sapphire-blue focus glow (`#1a73e8`, 2px outline and 28px soft diffused ambient glow)
+  - `material-you`: focus glow following the current Noctalia palette (wallpaper Material You or a built-in scheme)
 
 | Command | Description |
 | :--- | :--- |

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -127,7 +127,8 @@ NyxNiri
   - `transparent`：75% 半透明高透风味
 - **`niri`**：
   - `default`：极致极简无边框（默认）
-  - `glow`：启用 2px 轮廓与 28px 柔和弥散光晕（解决多窗口平铺下的焦点识别问题）
+  - `sapphire-blue`：宝石蓝聚焦光晕（`#1a73e8`，2px 轮廓与 28px 柔和弥散光晕）
+  - `material-you`：聚焦光晕跟随 Noctalia 当前配色（壁纸取色或内置盘）
 
 | 指令 | 作用 |
 | :--- | :--- |

--- a/configs/niri/.module.toml
+++ b/configs/niri/.module.toml
@@ -10,5 +10,5 @@ preserve = ["monitor.kdl", "effects.kdl"]
 chmod = ["scripts/*.sh"]
 
 [presets]
-allow = ["glow"]
+allow = ["sapphire-blue", "material-you"]
 include = ["scripts/**", "*.kdl", "orbit-items__custom__.toml"]

--- a/configs/niri/config.kdl
+++ b/configs/niri/config.kdl
@@ -40,6 +40,7 @@ spawn-at-startup "~/.config/niri/scripts/start-noctalia.sh"
 // niri does not consume /etc/xdg/autostart entries on its own.
 spawn-at-startup "sh" "-c" "command -v fcitx5 >/dev/null 2>&1 && exec fcitx5 -d"
 spawn-at-startup "~/.config/niri/scripts/toggle-eyecare.sh" "--sync"
+spawn-at-startup "~/.config/niri/scripts/sync-focus-glow.sh"
 // Re-render GTK M3 templates after Noctalia palette is ready (~8s on cold start)
 spawn-at-startup "bash" "-c" "sleep 8; noctalia msg config-reload && noctalia msg templates-apply"
 

--- a/configs/niri/presets/material-you/layout.kdl
+++ b/configs/niri/presets/material-you/layout.kdl
@@ -1,0 +1,50 @@
+window-rule {
+    // 圆角
+    geometry-corner-radius 12
+    // 去掉超出圆角的窗口内容
+    clip-to-geometry true
+    // 禁止边框画到背景里
+    draw-border-with-background false
+}
+
+layout {
+    // 从 glassy-niri 引入的平铺区深色背景，取消注释可体验：
+    // background-color "00000020"
+    background-color "transparent"
+    gaps 12
+    center-focused-column "never"
+    always-center-single-column
+    preset-column-widths {
+        proportion 0.33333
+        proportion 0.5
+        proportion 0.66667
+    }
+    default-column-width { proportion 0.5; }
+    // Fallback until Noctalia renders the active palette into this file.
+    focus-ring {
+        width 2
+        active-color "#1a73e8"
+        inactive-color "transparent"
+        urgent-color "#ffb4ab"
+    }
+    shadow {
+        on
+        softness 28
+        spread 6
+        offset x=0 y=0
+        draw-behind-window false
+        color "#1a73e895"
+        inactive-color "#00000045"
+    }
+
+
+    tab-indicator {
+        active-color "#b6c7e7"
+        inactive-color "#374761"
+        urgent-color "#ffb4ab"
+    }
+
+    insert-hint {
+        color "#b6c7e780"
+    }
+}

--- a/configs/niri/presets/material-you/material-you.enabled
+++ b/configs/niri/presets/material-you/material-you.enabled
@@ -1,0 +1,1 @@
+# Sentinel: while this file exists, Noctalia renders palette colors into layout.kdl.

--- a/configs/niri/presets/sapphire-blue/layout-dark.kdl
+++ b/configs/niri/presets/sapphire-blue/layout-dark.kdl
@@ -20,6 +20,7 @@ layout {
         proportion 0.66667
     }
     default-column-width { proportion 0.5; }
+    // Dark: match material-you glow parameters, with sapphire-blue.
     focus-ring {
         width 2
         active-color "#1a73e8"

--- a/configs/niri/presets/sapphire-blue/layout-light.kdl
+++ b/configs/niri/presets/sapphire-blue/layout-light.kdl
@@ -1,0 +1,50 @@
+window-rule {
+    // 圆角
+    geometry-corner-radius 12
+    // 去掉超出圆角的窗口内容
+    clip-to-geometry true
+    // 禁止边框画到背景里
+    draw-border-with-background false
+}
+
+layout {
+    // 从 glassy-niri 引入的平铺区深色背景，取消注释可体验：
+    // background-color "00000020"
+    background-color "transparent"
+    gaps 12
+    center-focused-column "never"
+    always-center-single-column
+    preset-column-widths {
+        proportion 0.33333
+        proportion 0.5
+        proportion 0.66667
+    }
+    default-column-width { proportion 0.5; }
+    // Light: 2px solid ring as a visual anchor on bright wallpapers.
+    focus-ring {
+        width 2
+        active-color "#1a73e8"
+        inactive-color "transparent"
+        urgent-color "#ffb4ab"
+    }
+    shadow {
+        on
+        softness 26
+        spread 6
+        offset x=0 y=0
+        draw-behind-window false
+        color "#1a73e895"
+        inactive-color "#00000028"
+    }
+
+
+    tab-indicator {
+        active-color "#b6c7e7"
+        inactive-color "#374761"
+        urgent-color "#ffb4ab"
+    }
+
+    insert-hint {
+        color "#b6c7e780"
+    }
+}

--- a/configs/niri/presets/sapphire-blue/layout.kdl
+++ b/configs/niri/presets/sapphire-blue/layout.kdl
@@ -1,0 +1,50 @@
+window-rule {
+    // 圆角
+    geometry-corner-radius 12
+    // 去掉超出圆角的窗口内容
+    clip-to-geometry true
+    // 禁止边框画到背景里
+    draw-border-with-background false
+}
+
+layout {
+    // 从 glassy-niri 引入的平铺区深色背景，取消注释可体验：
+    // background-color "00000020"
+    background-color "transparent"
+    gaps 12
+    center-focused-column "never"
+    always-center-single-column
+    preset-column-widths {
+        proportion 0.33333
+        proportion 0.5
+        proportion 0.66667
+    }
+    default-column-width { proportion 0.5; }
+    // Fallback (light). sync-focus-glow.sh replaces this with layout-dark/light.kdl.
+    focus-ring {
+        width 2
+        active-color "#1a73e8"
+        inactive-color "transparent"
+        urgent-color "#ffb4ab"
+    }
+    shadow {
+        on
+        softness 26
+        spread 6
+        offset x=0 y=0
+        draw-behind-window false
+        color "#1a73e895"
+        inactive-color "#00000028"
+    }
+
+
+    tab-indicator {
+        active-color "#b6c7e7"
+        inactive-color "#374761"
+        urgent-color "#ffb4ab"
+    }
+
+    insert-hint {
+        color "#b6c7e780"
+    }
+}

--- a/configs/niri/scripts/sync-focus-glow.sh
+++ b/configs/niri/scripts/sync-focus-glow.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Swap sapphire-blue layout.kdl between dark/light variants.
+# No-op for any other niri preset (default / material-you / user).
+set -uo pipefail
+
+NIRI_DIR="${HOME}/.config/niri"
+PRESET_FILE="${HOME}/.config/NyxNiri/presets/niri.active"
+DARK_KDL="${NIRI_DIR}/layout-dark.kdl"
+LIGHT_KDL="${NIRI_DIR}/layout-light.kdl"
+DEST_KDL="${NIRI_DIR}/layout.kdl"
+
+preset="default"
+if [ -f "$PRESET_FILE" ]; then
+    preset=$(tr -d '[:space:]' < "$PRESET_FILE" 2>/dev/null || echo "default")
+fi
+if [ "$preset" != "sapphire-blue" ]; then
+    exit 0
+fi
+if [ ! -f "$DARK_KDL" ] || [ ! -f "$LIGHT_KDL" ]; then
+    exit 0
+fi
+
+MODE="${1:-}"
+if [ "$MODE" != "dark" ] && [ "$MODE" != "light" ]; then
+    MODE=""
+    if command -v noctalia >/dev/null 2>&1 && noctalia msg status >/dev/null 2>&1; then
+        MODE=$(noctalia msg theme-mode-get 2>/dev/null || echo "")
+    fi
+    if [ -z "$MODE" ] || [ "$MODE" = "auto" ] || [ "$MODE" = "unknown" ]; then
+        if command -v gsettings >/dev/null 2>&1; then
+            scheme=$(gsettings get org.gnome.desktop.interface color-scheme 2>/dev/null | tr -d "'" || echo "")
+            if [ "$scheme" = "prefer-light" ] || [ "$scheme" = "default" ]; then
+                MODE="light"
+            else
+                MODE="dark"
+            fi
+        else
+            MODE="dark"
+        fi
+    fi
+fi
+
+SRC="$DARK_KDL"
+if [ "$MODE" = "light" ]; then
+    SRC="$LIGHT_KDL"
+fi
+
+if [ -f "$DEST_KDL" ] && cmp -s "$SRC" "$DEST_KDL"; then
+    exit 0
+fi
+
+tmp=$(mktemp "${DEST_KDL}.XXXXXX") || exit 1
+cp "$SRC" "$tmp"
+chmod --reference="$SRC" "$tmp" 2>/dev/null || chmod 644 "$tmp"
+mv -f "$tmp" "$DEST_KDL"
+
+if command -v niri >/dev/null 2>&1; then
+    niri msg action load-config-file >/dev/null 2>&1 || true
+fi

--- a/configs/noctalia/README.md
+++ b/configs/noctalia/README.md
@@ -32,12 +32,13 @@ configs/noctalia/
 ├── mpvpaper-sync.sh       ← mpvpaper 视频壁纸同步
 └── templates/
     ├── gtk-3.0.css        ← GTK3 M3 模板（无条件 @define-color）
-    └── gtk-4.0.css        ← GTK4 M3 模板（双 @media 块）
+    ├── gtk-4.0.css        ← GTK4 M3 模板（双 @media 块）
+    └── niri-material-you.kdl ← Niri material-you 焦点环/光晕（跟随当前配色）
 ```
 
 ### theme-sync.sh — 调度中枢
 
-`theme-sync.sh` 在深浅切换时运行，按 step 1-9 执行：
+`theme-sync.sh` 在深浅切换时运行，按 step 1-10 执行：
 
 | Step | 职责 | 说明 |
 |---|---|---|
@@ -49,14 +50,16 @@ configs/noctalia/
 | 6 | gsettings 广播 | `color-scheme` + `gtk-theme` 立即广播 |
 | 7 | settings.ini 同步 | 写入 `gtk-{3,4}.0/settings.ini` |
 | 8 | 热重载 | Kitty `SIGUSR1` + Kvantum |
-| 9 | 交互反馈 | 终端运行时打印结果 |
+| 9 | sapphire-blue 焦点环 | 深浅切换时替换 `layout-dark.kdl` / `layout-light.kdl` |
+| 10 | 交互反馈 | 终端运行时打印结果 |
 
 ### noctalia-config.toml — 注册中心
 
 - **hook 注册**：`theme_mode_changed` → `theme-sync.sh`
 - **hook 注册**：`wallpaper_changed` → `wallpaper-hook.sh`
-- **user template 注册**：`nyxniri_gtk3` / `nyxniri_gtk4`
+- **user template 注册**：`nyxniri_gtk3` / `nyxniri_gtk4` / `nyxniri_niri_material_you`
 - `/home/user` 占位符由 `nyxniri.deploy` 在部署时替换为实际 `$HOME`
+- **`nyxniri_niri_material_you`**：输出到 `~/.config/noctalia/templates/niri-material-you.rendered.kdl`。`post_hook` 检查哨兵 `material-you.enabled`，仅在该预设启用时拷入 `~/.config/niri/layout.kdl` 并触发 `niri msg action load-config-file`，彻底杜绝无条件覆写 default / sapphire-blue。
 
 ### templates/gtk-3.0.css — GTK3 M3 模板
 
@@ -303,6 +306,12 @@ output_path = "/home/user/.config/gtk-3.0/gtk.css"
 index = 4
 input_path = "/home/user/.config/noctalia/templates/gtk-4.0.css"
 output_path = "/home/user/.config/gtk-4.0/gtk.css"
+
+[theme.templates.user.nyxniri_niri_material_you]
+index = 5
+input_path = "/home/user/.config/noctalia/templates/niri-material-you.kdl"
+output_path = "/home/user/.config/noctalia/templates/niri-material-you.rendered.kdl"
+post_hook = "if [ -f /home/user/.config/niri/material-you.enabled ]; then cp -f /home/user/.config/noctalia/templates/niri-material-you.rendered.kdl /home/user/.config/niri/layout.kdl && command -v niri >/dev/null 2>&1 && niri msg action load-config-file; fi"
 ```
 
 模板部署后由 `nyxniri/modules/gtktheme.py` 的 `gtktheme_trigger_render()` 调用
@@ -620,6 +629,7 @@ nyxniri theme light
 | `configs/noctalia/noctalia-config.toml` | hook + user template 注册 |
 | `configs/noctalia/templates/gtk-3.0.css` | GTK3 M3 模板 |
 | `configs/noctalia/templates/gtk-4.0.css` | GTK4 M3 模板（双 @media） |
+| `configs/noctalia/templates/niri-material-you.kdl` | Niri material-you 焦点环/光晕（跟随当前配色） |
 | `configs/noctalia/wallpaper-hook.sh` | 壁纸切换 hook |
 | `configs/noctalia/mpvpaper-sync.sh` | mpvpaper 同步 |
 | `nyxniri/modules/gtktheme.py` | `nyxniri gtk install\|status\|uninstall` |

--- a/configs/noctalia/noctalia-config.toml
+++ b/configs/noctalia/noctalia-config.toml
@@ -243,6 +243,15 @@ index = 4
 input_path = "/home/user/.config/noctalia/templates/gtk-4.0.css"
 output_path = "/home/user/.config/gtk-4.0/gtk.css"
 
+# Niri material-you 预设：焦点环与光晕跟随 Noctalia 当前配色（壁纸或内置盘）。
+# 模板渲染到独立的 niri-material-you.rendered.kdl，由 post_hook 在且仅在 material-you 启用时拷入 layout.kdl。
+# 避免 Noctalia 模板渲染无条件覆盖 default / sapphire-blue 预设。
+[theme.templates.user.nyxniri_niri_material_you]
+index = 5
+input_path = "/home/user/.config/noctalia/templates/niri-material-you.kdl"
+output_path = "/home/user/.config/noctalia/templates/niri-material-you.rendered.kdl"
+post_hook = "if [ -f /home/user/.config/niri/material-you.enabled ]; then cp -f /home/user/.config/noctalia/templates/niri-material-you.rendered.kdl /home/user/.config/niri/layout.kdl && command -v niri >/dev/null 2>&1 && niri msg action load-config-file; fi"
+
 [wallpaper]
 directory = "/home/user/图片/Wallpapers"
 fill_mode = "crop"

--- a/configs/noctalia/templates/niri-material-you.kdl
+++ b/configs/noctalia/templates/niri-material-you.kdl
@@ -1,0 +1,49 @@
+window-rule {
+    // 圆角
+    geometry-corner-radius 12
+    // 去掉超出圆角的窗口内容
+    clip-to-geometry true
+    // 禁止边框画到背景里
+    draw-border-with-background false
+}
+
+layout {
+    // 从 glassy-niri 引入的平铺区深色背景，取消注释可体验：
+    // background-color "00000020"
+    background-color "transparent"
+    gaps 12
+    center-focused-column "never"
+    always-center-single-column
+    preset-column-widths {
+        proportion 0.33333
+        proportion 0.5
+        proportion 0.66667
+    }
+    default-column-width { proportion 0.5; }
+    focus-ring {
+        width 2
+        active-color "{{ colors.primary.default.hex }}"
+        inactive-color "transparent"
+        urgent-color "{{ colors.error.default.hex }}"
+    }
+    shadow {
+        on
+        softness 28
+        spread 6
+        offset x=0 y=0
+        draw-behind-window false
+        color "{{ colors.primary.default.hex }}95"
+        inactive-color "#00000045"
+    }
+
+
+    tab-indicator {
+        active-color "{{ colors.primary.default.hex }}"
+        inactive-color "{{ colors.primary_container.default.hex }}"
+        urgent-color "{{ colors.error.default.hex }}"
+    }
+
+    insert-hint {
+        color "{{ colors.primary.default.hex }}80"
+    }
+}

--- a/configs/noctalia/theme-sync.sh
+++ b/configs/noctalia/theme-sync.sh
@@ -209,7 +209,13 @@ if [ -d "/usr/share/Kvantum/$KVANTUM_THEME" ] || [ -d "$HOME/.config/Kvantum/$KV
     atomic_update_ini "$HOME/.config/Kvantum/kvantum.kvconfig" "theme" "$KVANTUM_THEME"
 fi
 
-# 9. Feedback for Interactive CLI Invocations
+# 9. Sapphire-blue focus ring: swap dark/light layout if that preset is active.
+GLOW_SYNC="$HOME/.config/niri/scripts/sync-focus-glow.sh"
+if [ -f "$GLOW_SYNC" ]; then
+    bash "$GLOW_SYNC" "$TARGET_MODE" >/dev/null 2>&1 || true
+fi
+
+# 10. Feedback for Interactive CLI Invocations
 if [ -t 1 ] && [ -n "$ACTION" ]; then
     echo "Theme synced to: $TARGET_MODE (Scheme: $SCHEME_VAL, GTK: $GTK_THEME)"
 fi

--- a/llms-wiki/delayed-decisions.md
+++ b/llms-wiki/delayed-decisions.md
@@ -14,7 +14,7 @@
 
 | 事项 | 原触发 | 实际 |
 |---|---|---|
-| **应用预设底版继承（Base Overlay）** | 预设文件量大、仅少数文件有差异 | **已落地**。`atomic_replace_item` 支持底版拷贝与白黑名单过滤（manifest `[presets]` 表 `allow`/`include`/`exclude`），Niri `glow` 仅需 49 行 `layout.kdl`。详见 [preset-mechanism](preset-mechanism.md) 与 [manifest-schema](manifest-schema.md) |
+| **应用预设底版继承（Base Overlay）** | 预设文件量大、仅少数文件有差异 | **已落地**。`atomic_replace_item` 支持底版拷贝与白黑名单过滤（manifest `[presets]` 表 `allow`/`include`/`exclude`），Niri `sapphire-blue` 仅需几份 `layout*.kdl`。详见 [preset-mechanism](preset-mechanism.md) 与 [manifest-schema](manifest-schema.md) |
 | **子目录分组**（deploy/state/modules 子包） | >28 文件 或 某子领域 >5 文件 | **已做**。重构前 17 个 .py（< 28 触发未到），但为贯彻 §13 目标结构主动拆了四个子包——有意识覆盖 §11 的延迟决策。详见 [subpackages](subpackages.md) |
 | **doctor 预设漂移检查** | preset 系统落地后即加 | **已加** `_check_preset_drift`：扫所有 app 的 active 预设是否还在仓库/用户预设目录，给汇总。平时不 update 也能在 doctor 撞见"你的 kitty 透明预设已不在上游"。符合 §4 扩展指南（写 `_check_xxx` append 到 `DOCTOR_CHECKS`，不碰 `run_doctor`） |
 

--- a/llms-wiki/manifest-schema.md
+++ b/llms-wiki/manifest-schema.md
@@ -18,7 +18,7 @@
 
 ### 预设继承控制（`[presets]` 表，可选）
 
-针对预设较多、希望支持轻量差异化预设（如 Niri `glow` 仅修改 `layout.kdl`）的应用，可通过 `[presets]` 表精确配置底版继承（Base Overlay）：
+针对预设较多、希望支持轻量差异化预设（如 Niri `sapphire-blue` 仅修改 `layout.kdl`）的应用，可通过 `[presets]` 表精确配置底版继承（Base Overlay）：
 
 | 字段 | 默认 | 作用 |
 |---|---|---|
@@ -39,7 +39,7 @@ preserve = ["monitor.kdl", "effects.kdl"]
 chmod = ["scripts/*.sh"]
 
 [presets]
-allow = ["glow"]
+allow = ["sapphire-blue", "material-you"]
 include = ["scripts/**", "*.kdl", "orbit-items__custom__.toml"]
 
 # configs/fish/.module.toml — clean-cache.py 不是 .sh，需声明 chmod

--- a/llms-wiki/preset-mechanism.md
+++ b/llms-wiki/preset-mechanism.md
@@ -67,9 +67,9 @@ theme-sync / gtk 重渲染）。切个 kitty 预设不该顺带跑 fisher，无�
 
 三层堆叠正式落地：`configs/<app>` (Base) ← `presets/<name>` (Overlay) ← `__custom__` (Dunder) / `preserve` (Manifest)。
 
-- **稀疏预设 (Sparse Presets)**：预设目录只需要存放与默认配置有差异的文件（例如 Niri 的 `glow` 仅需 49 行的 `layout.kdl`，无需镜像复制 4000+ 行 Python 脚本）。未重写的文件自动从仓库底版继承。
+- **稀疏预设 (Sparse Presets)**：预设目录只需要存放与默认配置有差异的文件（例如 Niri 的 `sapphire-blue` 仅需几份 `layout*.kdl`，无需镜像复制 4000+ 行 Python 脚本）。未重写的文件自动从仓库底版继承。
 - **双轴白名单保障**：
-  - **预设名白名单 (`allow = ["glow"]`)**：仅列入白名单的预设开启继承；未列入的预设和未声明的应用（如 Kitty）保持 100% 独立，零配置渗透。
+  - **预设名白名单 (`allow = ["sapphire-blue", "material-you"]`)**：仅列入白名单的预设开启继承；未列入的预设和未声明的应用（如 Kitty）保持 100% 独立，零配置渗透。
   - **文件白名单 (`include = ["scripts/**", "*.kdl"]`)**：仅继承白名单允许的底版文件；支持 `exclude` 黑名单进一步剔除特定文件。
 - **原子组装**：由 `atomic_replace_item(..., base_src, base_include, base_exclude)` 在 `tmp_new` 组装：先拷贝并过滤底版，再覆盖预设自身文件，最后注入 `__custom__` 与受保护文件，一次性原子 swap。
 

--- a/nyxniri/deploy/preset.py
+++ b/nyxniri/deploy/preset.py
@@ -571,6 +571,33 @@ def apply_preset(app: str, name: str) -> bool:
         return False
     _render_preset_result(app, name, preserved_log)
     if app == "niri" and shutil.which("niri"):
+        glow_sync = dest / "scripts" / "sync-focus-glow.sh"
+        if glow_sync.is_file():
+            timed_run(["bash", str(glow_sync)], 5, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
+        # material-you sentinel: palette is already current, so a reload+apply is
+        # safe here (unlike theme-sync, which races Noctalia's wallpaper recast).
+        # config-reload first so a just-registered user template is picked up.
+        if (dest / "material-you.enabled").is_file() and shutil.which("noctalia"):
+            rendered_tmpl = env.config_dir / "noctalia" / "templates" / "niri-material-you.rendered.kdl"
+            if rendered_tmpl.is_file():
+                try:
+                    shutil.copy2(rendered_tmpl, dest / "layout.kdl")
+                except OSError:
+                    pass
+            timed_run(
+                ["noctalia", "msg", "config-reload"],
+                15,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
+            timed_run(
+                ["noctalia", "msg", "templates-apply"],
+                30,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                check=False,
+            )
         timed_run(["niri", "msg", "action", "load-config-file"], 2, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)
     elif app == "kitty" and shutil.which("pkill"):
         timed_run(["pkill", "-SIGUSR1", "-x", "kitty"], 2, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, check=False)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -159,6 +159,7 @@ class TestRealRepoManifests(unittest.TestCase):
         self.assertTrue(m.is_deployable)
         # dir name = package = binary → no [packages] override needed
         self.assertEqual(m.packages_repo, ["niri"])
+        self.assertEqual(m.preset_allow, ["sapphire-blue", "material-you"])
 
     def test_starship_sidecar(self):
         m = manifest.load_manifest(self.env.configs_src / "starship.toml")
@@ -261,7 +262,7 @@ class TestRealRepoManifests(unittest.TestCase):
 
     def test_real_niri_manifest_has_presets_whitelist(self):
         m = manifest.load_manifest_for("niri")
-        self.assertEqual(m.preset_allow, ["glow"])
+        self.assertEqual(m.preset_allow, ["sapphire-blue", "material-you"])
         self.assertIn("scripts/**", m.preset_include)
         self.assertIn("*.kdl", m.preset_include)
 

--- a/tests/test_preset.py
+++ b/tests/test_preset.py
@@ -226,29 +226,57 @@ class TestPresetOperations(unittest.TestCase):
         entries = preset.collect_presets("niri")
         names = [n for n, _, _ in entries]
         self.assertIn("default", names)
-        self.assertIn("glow", names)
+        self.assertIn("sapphire-blue", names)
+        self.assertIn("material-you", names)
 
     def test_apply_niri_glow_sparse_overlay_end_to_end(self):
-        ok = preset.apply_preset("niri", "glow")
+        ok = preset.apply_preset("niri", "sapphire-blue")
         self.assertTrue(ok)
-        self.assertEqual(preset.read_active_preset("niri"), "glow")
+        self.assertEqual(preset.read_active_preset("niri"), "sapphire-blue")
 
-        # Overridden sparse file
-        layout = self.env.config_dir / "niri" / "layout.kdl"
+        dest = self.env.config_dir / "niri"
+        layout = dest / "layout.kdl"
+        self.assertTrue(layout.is_file())
+        self.assertIn("shadow", layout.read_text())
+        self.assertTrue((dest / "layout-dark.kdl").is_file())
+        self.assertTrue((dest / "layout-light.kdl").is_file())
+        self.assertIn("width 2", (dest / "layout-dark.kdl").read_text())
+        self.assertIn("width 2", (dest / "layout-light.kdl").read_text())
+
+        config = dest / "config.kdl"
+        self.assertTrue(config.is_file())
+        launcher = dest / "scripts" / "orbit-launcher.py"
+        self.assertTrue(launcher.is_file())
+        self.assertFalse((dest / "material-you.enabled").exists())
+
+    def test_apply_niri_glow_m3_sparse_overlay_end_to_end(self):
+        ok = preset.apply_preset("niri", "material-you")
+        self.assertTrue(ok)
+        self.assertEqual(preset.read_active_preset("niri"), "material-you")
+
+        dest = self.env.config_dir / "niri"
+        layout = dest / "layout.kdl"
         self.assertTrue(layout.is_file())
         self.assertIn("width 2", layout.read_text())
-        self.assertIn("shadow", layout.read_text())
+        self.assertTrue((dest / "material-you.enabled").is_file())
+        self.assertTrue((dest / "config.kdl").is_file())
+        self.assertTrue((dest / "scripts" / "orbit-launcher.py").is_file())
 
-        # Inherited base files
-        config = self.env.config_dir / "niri" / "config.kdl"
-        self.assertTrue(config.is_file())
-        launcher = self.env.config_dir / "niri" / "scripts" / "orbit-launcher.py"
-        self.assertTrue(launcher.is_file())
+    def test_niri_glow_m3_template_uses_m3_tokens(self):
+        tmpl = self.env.configs_src / "noctalia" / "templates" / "niri-material-you.kdl"
+        text = tmpl.read_text()
+        self.assertIn("{{ colors.primary.default.hex }}", text)
+        self.assertIn("{{ colors.error.default.hex }}", text)
+        self.assertIn("{{ colors.primary_container.default.hex }}", text)
+        self.assertNotIn("#1a73e8", text)
+        toml = (self.env.configs_src / "noctalia" / "noctalia-config.toml").read_text()
+        self.assertIn("theme.templates.user.nyxniri_niri_material_you", toml)
+        self.assertIn("material-you.enabled", toml)
 
     @unittest.mock.patch("nyxniri.deploy.preset.timed_run")
     @unittest.mock.patch("shutil.which", return_value="/usr/bin/niri")
     def test_apply_preset_niri_reloads(self, mock_which, mock_timed_run):
-        ok = preset.apply_preset("niri", "glow")
+        ok = preset.apply_preset("niri", "sapphire-blue")
         self.assertTrue(ok)
         mock_timed_run.assert_called_with(
             ["niri", "msg", "action", "load-config-file"],
@@ -256,6 +284,50 @@ class TestPresetOperations(unittest.TestCase):
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
             check=False,
+        )
+        noctalia_calls = [
+            c for c in mock_timed_run.call_args_list
+            if c.args and c.args[0][:1] == ["noctalia"]
+        ]
+        self.assertEqual(noctalia_calls, [])
+
+    @unittest.mock.patch("nyxniri.deploy.preset.timed_run")
+    def test_apply_preset_niri_glow_m3_renders_then_reloads(self, mock_timed_run):
+        def fake_which(cmd):
+            return f"/usr/bin/{cmd}"
+
+        with patch("shutil.which", side_effect=fake_which):
+            ok = preset.apply_preset("niri", "material-you")
+        self.assertTrue(ok)
+        mock_timed_run.assert_any_call(
+            ["noctalia", "msg", "config-reload"],
+            15,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        mock_timed_run.assert_any_call(
+            ["noctalia", "msg", "templates-apply"],
+            30,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        mock_timed_run.assert_any_call(
+            ["niri", "msg", "action", "load-config-file"],
+            2,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            check=False,
+        )
+        calls = [c.args[0] for c in mock_timed_run.call_args_list]
+        self.assertLess(
+            calls.index(["noctalia", "msg", "config-reload"]),
+            calls.index(["noctalia", "msg", "templates-apply"]),
+        )
+        self.assertLess(
+            calls.index(["noctalia", "msg", "templates-apply"]),
+            calls.index(["niri", "msg", "action", "load-config-file"]),
         )
 
     @unittest.mock.patch("nyxniri.deploy.preset.timed_run")


### PR DESCRIPTION
## 描述 (Description)

响应 #100 与 maintainer 在 #101 中的建议（*“有空可以做一个响应noctalia m3 配色的版本哦~”*），为 Niri 聚焦指示器引入 Material You 动态配色支持，并将原有固定蓝拆分为独立的自适应预设：

### 1. 新增 `material-you` 官方预设
- **动态跟随桌面配色**：通过 Noctalia 用户模板与哨兵机制，窗口焦点环与弥散光晕（2px 轮廓边框 + 28px 柔和弥散光晕）颜色动态响应壁纸 M3 主色调或当前选用的调色板。
- **模板隔离渲染架构**：模板输出设定至中间文件 `~/.config/noctalia/templates/niri-material-you.rendered.kdl`，由 `post_hook` 判定仅在当前激活 `material-you.enabled` 哨兵时才拷入 `layout.kdl` 并通知 Niri 重载，杜绝模板渲染对 `default` 或 `sapphire-blue` 的无条件覆写。

### 2. 重命名并完善 `sapphire-blue` 预设
- 原固定电光蓝预设重命名为更直观的 **`sapphire-blue`**（宝石蓝），与动态跟随的 `material-you` 清晰区分。
- **完善深浅自适应联动**：
  - **浅色模式**：2px 实体轮廓（`#1a73e8`）+ 26px 柔光；
  - **深色模式**：保持与 `material-you` 一致的高清光晕质感（2px 轮廓 `#1a73e8` + 28px 弥散光晕 `#1a73e895`，暗场阴影 `#00000045`），深色背景下边界清晰且自然通透。
  - 通过 `theme-sync.sh` 与 `sync-focus-glow.sh` 在深浅切换时平滑热重载。

### 3. 严格遵循稀疏预设（Sparse Preset）底版继承机制
- 坚决杜绝整树复制配置：预设目录下仅存放微量的差异布局文件（`layout*.kdl`）与哨兵文件，其余全部配置（rules、binds、animations、scripts 等）100% 自动继承自 `configs/niri/` 仓库底版，零维护冗余。

### 4. 文档与测试全覆盖
- 同步更新中英文主页文档（`README.md` / `README.zh-CN.md`）、`CHANGELOG.md`、`configs/noctalia/README.md` 及 `llms-wiki` 架构文档。
- 完善 `tests/test_preset.py` 与 `tests/test_manifest.py`，全量 399 项单元测试全绿通过。

Closes #100